### PR TITLE
Implemented Query Form Config Service - evolution step 4

### DIFF
--- a/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/ListField.java
+++ b/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/ListField.java
@@ -36,9 +36,9 @@ public class ListField extends QueryFormField {
 
     public static final String EXTRA_ATTR_VALUE_SERVICE = "valueService";
 
-    public static final String EXTRA_ATTR_ID_FIELD = "idField";
+    public static final String EXTRA_ATTR_ID_FIELD = "valueId";
 
-    public static final String EXTRA_ATTR_LABEL_FIELD = "labelField";
+    public static final String EXTRA_ATTR_LABEL_FIELD = "valueLabel";
 
     public static final String DEFAULT_ID_FIELD = "id";
 
@@ -52,9 +52,9 @@ public class ListField extends QueryFormField {
 
     private URL valueService;
 
-    private String idField;
+    private String valueId;
 
-    private String labelField;
+    private String valueLabel;
 
     ListField() {
         super(QueryFormFieldType.list);
@@ -125,15 +125,15 @@ public class ListField extends QueryFormField {
      * @return the name of the ID field
      */
     @JsonSerialize(include = Inclusion.NON_NULL)
-    public String getIdField() {
-        return idField;
+    public String getValueId() {
+        return valueId;
     }
 
-    public void setIdField(String idField) {
-        if (!StringUtils.hasText(idField)) {
-            this.idField = DEFAULT_ID_FIELD;
+    public void setValueId(String valueId) {
+        if (!StringUtils.hasText(valueId)) {
+            this.valueId = DEFAULT_ID_FIELD;
         } else {
-            this.idField = idField;
+            this.valueId = valueId;
         }
     }
 
@@ -142,15 +142,15 @@ public class ListField extends QueryFormField {
      * @return the name of the field to be used as textual description
      */
     @JsonSerialize(include = Inclusion.NON_NULL)
-    public String getLabelField() {
-        return labelField;
+    public String getValueLabel() {
+        return valueLabel;
     }
 
-    public void setLabelField(String labelField) {
-        if (!StringUtils.hasText(labelField)) {
-            this.labelField = DEFAULT_LABEL_FIELD;
+    public void setValueLabel(String valueLabel) {
+        if (!StringUtils.hasText(valueLabel)) {
+            this.valueLabel = DEFAULT_LABEL_FIELD;
         } else {
-            this.labelField = labelField;
+            this.valueLabel = valueLabel;
         }
     }
 
@@ -176,11 +176,11 @@ public class ListField extends QueryFormField {
             parseValueServiceAttribute(value);
         } else if (EXTRA_ATTR_ID_FIELD.equals(name)) {
             if (value != null && value instanceof String) {
-                setIdField(value.toString());
+                setValueId(value.toString());
             }
         } else if (EXTRA_ATTR_LABEL_FIELD.equals(name)) {
             if (value != null && value instanceof String) {
-                setLabelField(value.toString());
+                setValueLabel(value.toString());
             }
         } else {
             logger.debug("unknown attribute specified : '" + name + "'");

--- a/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/QueryFormConfig.java
+++ b/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/QueryFormConfig.java
@@ -12,11 +12,26 @@ import java.util.List;
 public class QueryFormConfig {
 
     private String featureTypeName;
+    private String featureTypeNameLabel;
+    private String geometricField;
     private List<QueryFormField> fields;
 
     QueryFormConfig(String featureTypeName) {
         this.featureTypeName = featureTypeName;
+        this.featureTypeNameLabel = featureTypeName;
+        this.geometricField = "geometry";
         fields = new ArrayList<QueryFormField>();
+    }
+
+    public QueryFormConfig(String featureTypeName, String featureTypeNameLabel) {
+        this(featureTypeName);
+        this.featureTypeNameLabel = featureTypeNameLabel;
+    }
+
+    public QueryFormConfig(String featureTypeName, String featureTypeNameLabel,
+            String geometricField) {
+        this(featureTypeName, featureTypeNameLabel);
+        this.geometricField = geometricField;
     }
 
     /**
@@ -25,6 +40,22 @@ public class QueryFormConfig {
      */
     public String getFeatureTypeName() {
         return featureTypeName;
+    }
+
+    /**
+     * 
+     * @return the display name of the feature type associated to the query form configuration
+     */
+    public String getFeatureTypeNameLabel() {
+        return featureTypeNameLabel;
+    }
+
+    /**
+     * 
+     * @return the name of the geometry field in the feature type associated to the query form configuration
+     */
+    public String getGeometricField() {
+        return geometricField;
     }
 
     /**

--- a/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/QueryFormField.java
+++ b/backend/src/main/java/it/geosolutions/csi/sira/backend/queryform/model/QueryFormField.java
@@ -1,10 +1,10 @@
 package it.geosolutions.csi.sira.backend.queryform.model;
 
+import it.geosolutions.csi.sira.backend.queryform.model.parser.AttributeParser;
+
 import javax.xml.bind.annotation.XmlTransient;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
-
-import it.geosolutions.csi.sira.backend.queryform.model.parser.AttributeParser;
 
 /**
  * Base class for query form field types.
@@ -15,6 +15,7 @@ import it.geosolutions.csi.sira.backend.queryform.model.parser.AttributeParser;
 public abstract class QueryFormField {
 
     protected String id;
+    protected String name;
     protected QueryFormFieldType type;
     protected AttributeParser attributeParser;
 
@@ -50,6 +51,14 @@ public abstract class QueryFormField {
      */
     public String getId() {
         return id;
+    }
+
+    /**
+     * 
+     * @return the human readable field name
+     */
+    public String getFieldName() {
+        return name;
     }
 
     /**

--- a/backend/src/test/java/it/geosolutions/csi/sira/backend/queryform/model/PropertiesFileQueryFormConfigProviderTest.java
+++ b/backend/src/test/java/it/geosolutions/csi/sira/backend/queryform/model/PropertiesFileQueryFormConfigProviderTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,15 +26,19 @@ public class PropertiesFileQueryFormConfigProviderTest {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(PropertiesFileQueryFormConfigProviderTest.class);
 
-    private static final String TEST_FEATURE_TYPE_NAME = "test-feature";
+    private static final int NUM_PROPERTIES = 23;
+    private static final String TEST_FEATURE_TYPE_CONFIG_NAME = "test-feature";
+    private static final String TEST_FEATURE_TYPE_NAME = "cite:TestFeature";
+    private static final String TEST_FEATURE_TYPE_LABEL = "Test Feature";
+    private static final String TEST_FEATURE_TYPE_GEOMETRY = "geometria";
 
     @Test
     public void testLoadFromClasspath() {
         PropertiesFileQueryFormConfigProvider provider = new PropertiesFileQueryFormConfigProvider();
         try {
-            Properties p = provider.loadFromClasspath(TEST_FEATURE_TYPE_NAME);
+            Properties p = provider.loadFromClasspath(TEST_FEATURE_TYPE_CONFIG_NAME);
             assertNotNull(p);
-            assertEquals(18, p.keySet().size());
+            assertEquals(NUM_PROPERTIES, p.keySet().size());
         } catch (IOException e) {
             LOGGER.error("Exception trown loading configuration from classpath", e);
             fail();
@@ -50,7 +55,7 @@ public class PropertiesFileQueryFormConfigProviderTest {
             tempDir = tempDirPath.toFile();
 
             // copy config file to temp directory
-            String resourceName = TEST_FEATURE_TYPE_NAME + ".properties";
+            String resourceName = TEST_FEATURE_TYPE_CONFIG_NAME + ".properties";
             tempFile = new File(tempDir, resourceName);
             Files.copy(getClass().getResourceAsStream("/" + resourceName),
                     Paths.get(tempFile.getPath()));
@@ -64,9 +69,9 @@ public class PropertiesFileQueryFormConfigProviderTest {
                 assertTrue(provider.isConfigDirSet());
 
                 Properties p = provider.loadFromConfigDir(provider.getConfigDir(),
-                        TEST_FEATURE_TYPE_NAME);
+                        TEST_FEATURE_TYPE_CONFIG_NAME);
                 assertNotNull(p);
-                assertEquals(18, p.keySet().size());
+                assertEquals(NUM_PROPERTIES, p.keySet().size());
             } catch (IOException e) {
                 LOGGER.error("Exception trown loading configuration from configuration directory",
                         e);
@@ -92,15 +97,18 @@ public class PropertiesFileQueryFormConfigProviderTest {
         PropertiesFileQueryFormConfigProvider provider = new PropertiesFileQueryFormConfigProvider();
         provider.attributeParser = new JsonAttributeParser();
 
-        QueryFormConfig config = provider.getConfiguration(TEST_FEATURE_TYPE_NAME);
+        QueryFormConfig config = provider.getConfiguration(TEST_FEATURE_TYPE_CONFIG_NAME);
 
         assertNotNull(config);
         assertEquals(TEST_FEATURE_TYPE_NAME, config.getFeatureTypeName());
+        assertEquals(TEST_FEATURE_TYPE_LABEL, config.getFeatureTypeNameLabel());
+        assertEquals(TEST_FEATURE_TYPE_GEOMETRY, config.getGeometricField());
         assertNotNull(config.getFields());
         assertEquals(5, config.getFields().size());
 
         QueryFormField fieldColor = config.getFields().get(0);
         assertEquals("field-color", fieldColor.id);
+        assertEquals(fieldColor.id, fieldColor.name);
         assertEquals(QueryFormFieldType.list, fieldColor.type);
         List<Object> fieldColorValues = ((ListField) fieldColor).getValues();
         assertEquals(3, fieldColorValues.size());
@@ -110,10 +118,12 @@ public class PropertiesFileQueryFormConfigProviderTest {
 
         QueryFormField fieldPeriod = config.getFields().get(1);
         assertEquals("field-period", fieldPeriod.id);
+        assertEquals("Period", fieldPeriod.name);
         assertEquals(QueryFormFieldType.date, fieldPeriod.type);
 
         QueryFormField fieldShapeClass = config.getFields().get(2);
         assertEquals("field-shapeclass", fieldShapeClass.id);
+        assertEquals(fieldShapeClass.id, fieldShapeClass.name);
         assertEquals(QueryFormFieldType.list, fieldShapeClass.type);
         List<Object> fieldShapeClassValues = ((ListField) fieldShapeClass).getValues();
         assertEquals(2, fieldShapeClassValues.size());
@@ -128,6 +138,7 @@ public class PropertiesFileQueryFormConfigProviderTest {
 
         QueryFormField fieldShape = config.getFields().get(3);
         assertEquals("field-shape", fieldShape.id);
+        assertEquals("Geometric Shape", fieldShape.name);
         assertEquals(QueryFormFieldType.list, fieldShape.type);
         assertTrue(fieldShape instanceof ListField);
         ListField shape = (ListField) fieldShape;
@@ -150,6 +161,7 @@ public class PropertiesFileQueryFormConfigProviderTest {
 
         QueryFormField fieldRemote = config.getFields().get(4);
         assertEquals("field-remote", fieldRemote.id);
+        assertEquals(fieldRemote.id, fieldRemote.name);
         assertEquals(QueryFormFieldType.list, fieldRemote.type);
         assertTrue(fieldRemote instanceof ListField);
         ListField remote = (ListField) fieldRemote;
@@ -161,10 +173,10 @@ public class PropertiesFileQueryFormConfigProviderTest {
         assertEquals(
                 "service=WFS&version=1.1.0&request=GetFeature&typeName=cite:buildings&outputFormat=application/json",
                 remote.getValueService().getQuery());
-        assertNotNull(remote.getIdField());
-        assertEquals("id_building", remote.getIdField());
-        assertNotNull(remote.getLabelField());
-        assertEquals("description", remote.getLabelField());
+        assertNotNull(remote.getValueId());
+        assertEquals("id_building", remote.getValueId());
+        assertNotNull(remote.getValueLabel());
+        assertEquals("description", remote.getValueLabel());
     }
 
 }

--- a/backend/src/test/resources/test-feature.properties
+++ b/backend/src/test/resources/test-feature.properties
@@ -1,3 +1,7 @@
+name=cite:TestFeature
+label=Test Feature
+geometry=geometria
+
 fields=color,period,shapeclass,shape,remote
 
 color.id=field-color
@@ -5,6 +9,7 @@ color.type=list
 color.values="Red"|| "Green"|| "Blue" 
 
 period.id=field-period
+period.name=Period
 period.type=date
 
 shapeclass.id=field-shapeclass
@@ -12,6 +17,7 @@ shapeclass.type=list
 shapeclass.values={ "id": 1, "name": "Polygon" }||{ "id": 2, "name": "Curve" }
 
 shape.id=field-shape
+shape.name=Geometric Shape
 shape.type=list
 shape.dependson={ "field": "field-shapeclass", "from": "id", "to": "classId"}
 shape.values={ "id": 1, "classId": 1, "name": "Square" } || { "id": 2, "classId": 1, "name": "Rectangle" } || { "id": 3, "classId": 1, "name": "Triangle" }||{ "id": 4, "classId": 2, "name": "Circle" }||{ "id": 5, "classId": 2, "name": "Ellipsis" }
@@ -19,5 +25,5 @@ shape.values={ "id": 1, "classId": 1, "name": "Square" } || { "id": 2, "classId"
 remote.id=field-remote
 remote.type=list
 remote.valueService=http://localhost:8080/geoserver/ows?service=WFS&version=1.1.0&request=GetFeature&typeName=cite:buildings&outputFormat=application/json
-remote.idField=id_building
-remote.labelField=description
+remote.valueId=id_building
+remote.valueLabel=description


### PR DESCRIPTION
* Added `label` and `geometry` configuration properties, translated to `featureTypeNameLabel` and `geometricField` in JSON output.
* Renamed `idField` --> `valueId` and `labelField` --> `valueLabel` both in configuration file and JSON output.