### PR TITLE
Modified the metadata link section text

### DIFF
--- a/assets/cardTemplate.config
+++ b/assets/cardTemplate.config
@@ -32,7 +32,7 @@
         <MappaScheda center={model.geometry} authParam={model.authParam}/>
         </Section>
         <Section header='METADATI' eventKey='7'>
-            <LinkToPage url="http://www.geoportale.piemonte.it/geonetworkrp/srv/ita/metadata.show" params={{id: model.codicesira, currTab: 'rndt'}} />
+            <LinkToPage txt="Visualizza la scheda dei metadati" url="http://www.geoportale.piemonte.it/geonetworkrp/srv/ita/metadata.show" params={{id: 2658 || model.codicesira, currTab: 'rndt'}} />
         </Section>
     </Panel>
 </Panel>


### PR DESCRIPTION
- Modified the link text
- A temporary metadata id has been used because currently a relation between dataset and metadata does not exist yet.