### PR TITLE
No need to inspect request

### DIFF
--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideRoleService.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideRoleService.java
@@ -17,7 +17,6 @@
 package org.geoserver.security.iride;
 
 import static org.geoserver.security.iride.util.builder.IrideServerURLBuilder.buildServerURL;
-import static org.geoserver.security.iride.util.builder.ToStringReflectionBuilder.reflectToString;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -41,8 +40,6 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.apache.commons.httpclient.params.HttpConnectionManagerParams;
 import org.apache.commons.lang.StringUtils;
-import org.geoserver.ows.Dispatcher;
-import org.geoserver.ows.Request;
 import org.geoserver.security.GeoServerRoleService;
 import org.geoserver.security.GeoServerRoleStore;
 import org.geoserver.security.config.SecurityNamedServiceConfig;

--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideRoleService.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideRoleService.java
@@ -180,10 +180,6 @@ public class IrideRoleService extends AbstractGeoServerSecurityService implement
     public SortedSet<GeoServerRole> getRolesForUser(String username) throws IOException {
         LOGGER.info("Username: " + username);
 
-        final Request request = Dispatcher.REQUEST.get();
-
-        LOGGER.info("OWS Request: " + reflectToString(request));
-
         final TreeSet<GeoServerRole> roles = new TreeSet<GeoServerRole>();
 
         // Check username format: it may be an Identita Digitale IRIDE, or not


### PR DESCRIPTION
- at the present moment in development there's no need to inspect the ThreadLocal<Request> from Dispatcher
 - therefore removing useless imports
