### PR TITLE
Add Maven module "iride-entities" for IRIDE entity classes (issue #190)

### DIFF
--- a/security/iride-entities/LICENSE.txt
+++ b/security/iride-entities/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+    Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/security/iride-entities/README.md
+++ b/security/iride-entities/README.md
@@ -1,0 +1,7 @@
+IRIDE-ENTITIES
+==========
+
+Description
+------------
+
+In the context of **csi-sira** project, **iride-entities** stores the entity classes involved during authentication and authorization operations using [CSI Piemonte](http://www.csipiemonte.it/) IRIDE Service.

--- a/security/iride-entities/pom.xml
+++ b/security/iride-entities/pom.xml
@@ -75,6 +75,7 @@
         <java.version>1.7</java.version>
 
         <!-- Dependencies -->
+        <gs.version>2.8-SNAPSHOT</gs.version>
         <spring.version>3.1.4.RELEASE</spring.version>
         <spring-security.version>3.1.0.RELEASE</spring-security.version>
 
@@ -135,6 +136,13 @@
     </repositories>
 
     <dependencies>
+        <!-- GeoServer -->
+        <dependency>
+            <groupId>org.geoserver</groupId>
+            <artifactId>gs-main</artifactId>
+            <version>${gs.version}</version>
+        </dependency>
+
         <!-- Utilities -->
         <dependency>
             <groupId>commons-lang</groupId>

--- a/security/iride-entities/pom.xml
+++ b/security/iride-entities/pom.xml
@@ -1,0 +1,413 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.geoserver.security</groupId>
+    <artifactId>iride-entities</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>IRIDE entity classes</name>
+    <description>Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.</description>
+
+    <url>https://github.com/geosolutions-it/csi-sira/tree/master/security/iride-entities</url>
+    <inceptionYear>2016</inceptionYear>
+
+    <organization>
+        <name>CSI-Piemonte</name>
+        <url>http://www.csipiemonte.it</url>
+    </organization>
+
+    <developers>
+        <developer>
+          <id>seancrow76</id>
+          <name>Simone Cornacchia</name>
+          <email>simone.cornacchia AT assioma.net</email>
+          <organization>Assioma.net</organization>
+          <organizationUrl>http://www.assioma.net</organizationUrl>
+          <roles>
+            <role>architect</role>
+            <role>developer</role>
+          </roles>
+          <timezone>+1</timezone>
+          <properties>
+            <skype>seancrow76</skype>
+          </properties>
+          <url>https://github.com/seancrow</url>
+        </developer>
+    </developers>
+
+    <contributors>
+        <contributor>
+          <name>Diego Sanmartino</name>
+          <email>diego.sanmartino AT csi.it</email>
+          <organization>CSI-Piemonte</organization>
+          <organizationUrl>http://www.csipiemonte.it</organizationUrl>
+          <roles>
+            <role>architect</role>
+          </roles>
+          <timezone>+1</timezone>
+        </contributor>
+    </contributors>
+
+    <properties>
+        <!-- Java Version -->
+        <java.version>1.7</java.version>
+
+        <!-- Dependencies -->
+        <spring.version>3.1.4.RELEASE</spring.version>
+        <spring-security.version>3.1.0.RELEASE</spring-security.version>
+
+        <!-- Testing -->
+        <test.exclude.pattern>none</test.exclude.pattern>
+        <test.maxHeapSize>512M</test.maxHeapSize>
+        <test.maxPermSize>128M</test.maxPermSize>
+        <jvm.opts />
+        <java.awt.headless>true</java.awt.headless>
+        <remoteOwsTests>false</remoteOwsTests>
+        <test.allow.failure.ignore>false</test.allow.failure.ignore>
+
+        <!-- Build -->
+        <maven.build.timestamp.format>dd-MMM-yyyy HH:mm</maven.build.timestamp.format>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>boundless</id>
+            <name>Boundless Maven Repository</name>
+            <url>http://repo.boundlessgeo.com/main</url>
+            <!-- contains snapshot and release (including third-party-dependences) -->
+            <!-- Restlet maven Repository (http://maven.restlet.org) -->
+            <!-- ucar (https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases) -->
+            <!-- geosolutions (http://maven.geo-solutions.it/) -->
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>osgeo</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>http://download.osgeo.org/webdav/geotools/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>maven-restlet</id>
+            <name>Restlet Maven Repository</name>
+            <url>http://maven.restlet.org</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>geosolutions</id>
+            <name>GeoSolutions Repository</name>
+            <url>http://maven.geo-solutions.it</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <!-- Utilities -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+
+        <!-- Google Guava -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+        </dependency>
+
+        <!-- Test Dependencies (see https://tedvinke.wordpress.com/2013/12/17/mixing-junit-hamcrest-and-mockito-explaining-nosuchmethoderror/) -->
+
+        <!-- JUnit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hamcrest-core</artifactId>
+                    <groupId>org.hamcrest</groupId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Hamcrest -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- compilation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <!--debug>true</debug-->
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <!-- versioning -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.2.2</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+
+            <!-- resources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <!-- sources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <attach>true</attach>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- unit testing -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>${test.exclude.pattern}</exclude>
+                    </excludes>
+                    <forkMode>once</forkMode>
+                    <argLine>-Xmx${test.maxHeapSize} -XX:MaxPermSize=${test.maxPermSize} -enableassertions ${jvm.opts} -Djava.awt.headless=${java.awt.headless} -DremoteOwsTests=${remoteOwsTests} -Duser.language=EN</argLine>
+                    <printSummary>true</printSummary>
+                    <testFailureIgnore>${test.allow.failure.ignore}</testFailureIgnore>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.config.file</name>
+                            <value>src/test/resources/conf/logging.properties</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+
+            <!-- eclipse ide integration -->
+            <plugin>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <downloadSources>false</downloadSources>
+                    <additionalProjectnatures>
+                        <projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
+                    </additionalProjectnatures>
+                </configuration>
+            </plugin>
+
+            <!-- initialize git revision info -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- https://github.com/ktoso/maven-git-commit-id-plugin -->
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+                    <prefix>build</prefix>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <skipPoms>false</skipPoms>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+
+            <!-- packaging -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <GeoServerModule>extension</GeoServerModule>
+                            <Application-Name>${project.artifactId}-${project.version}</Application-Name>
+                            <Project-Version>${project.version}</Project-Version>
+                            <Build-Timestamp>${maven.build.timestamp}</Build-Timestamp>
+                            <Git-Revision>${build.commit.id}</Git-Revision>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <!-- javadoc -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <show>public</show>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <!-- surefire -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <showSuccess>false</showSuccess>
+                </configuration>
+            </plugin>
+            <!-- javadoc -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <show>private</show>
+                    <!-- https://web.archive.org/web/20071203010311/http://www.umlgraph.org/ -->
+                    <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
+                    <docletArtifact>
+                        <groupId>org.umlgraph</groupId>
+                        <artifactId>umlgraph</artifactId>
+                        <version>5.6.6</version>
+                    </docletArtifact>
+                    <additionalparam>-qualify -enumerations -postfixpackage -hide java.*|com.google.* -views -inferrel -inferreltype -inferdep -inferdepvis private</additionalparam>
+                    <useStandardDocletOptions>true</useStandardDocletOptions>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>javadoc-no-fork</report>
+                            <report>test-javadoc-no-fork</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <!-- cobertura -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <formats>
+                        <format>html</format>
+                        <format>xml</format>
+                    </formats>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/security/iride-entities/src/main/java/.gitignore
+++ b/security/iride-entities/src/main/java/.gitignore
@@ -1,4 +1,0 @@
-# Hack to commit empty folder: ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/security/iride-entities/src/main/java/.gitignore
+++ b/security/iride-entities/src/main/java/.gitignore
@@ -1,0 +1,4 @@
+# Hack to commit empty folder: ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideApplication.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideApplication.java
@@ -1,0 +1,114 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+/**
+ * <code>IRIDE</code> <code>Application</code> entity.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideApplication {
+
+    /**
+     * <code>IRIDE</code> <code>Application</code> string representation.
+     */
+    private static final String TO_STRING_FORMAT = "Application[%s]";
+
+    /**
+     * Application id.
+     */
+    private String id;
+
+    /**
+     * Constructor.
+     */
+    public IrideApplication() {
+        /* NOP */
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param id
+     */
+    public IrideApplication(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the id
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final HashCodeBuilder builder = new HashCodeBuilder();
+        builder.append(this.id);
+
+        return builder.toHashCode();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final IrideApplication other = (IrideApplication) obj;
+
+        final EqualsBuilder builder = new EqualsBuilder();
+        builder.append(this.id, other.id);
+
+        return builder.isEquals();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return String.format(TO_STRING_FORMAT, this.id);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideIdentity.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideIdentity.java
@@ -1,0 +1,491 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity;
+
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.geoserver.security.iride.entity.exception.IrideEntitySerializationException;
+import org.geoserver.security.iride.entity.identity.IrideIdentityFormatter;
+import org.geoserver.security.iride.entity.identity.IrideIdentityFormatter.FormatStyle;
+import org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer;
+import org.geoserver.security.iride.entity.identity.IrideIdentityValidator;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityInvalidTokensException;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityTokenizationException;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
+import org.geoserver.security.iride.entity.util.Utils;
+import org.geoserver.security.iride.entity.util.logging.LoggerProvider;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> entity.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentity implements Comparable<IrideIdentity>, Serializable {
+
+    private static final long serialVersionUID = -5499674345064933580L;
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerProvider.ENTITY.getLogger();
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> formatter instance.
+     */
+    private static final IrideIdentityFormatter FORMATTER = new IrideIdentityFormatter();
+
+    /**
+     * IRIDE <code>Digital Identity</code> tokenizer instance.
+     *
+     * @see IrideIdentityTokenizer
+     */
+    private static final IrideIdentityTokenizer TOKENIZER = new IrideIdentityTokenizer();
+
+    /**
+     * IRIDE <code>Digital Identity</code> validator instance.
+     *
+     * @see IrideIdentityValidator
+     */
+    private static final IrideIdentityValidator VALIDATOR = new IrideIdentityValidator();
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'Codice Fiscale' property.
+     */
+    private final String codFiscale;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'Nome' property.
+     */
+    private final String nome;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'Cognome' property.
+     */
+    private final String cognome;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'IdProvider' property.
+     */
+    private final String idProvider;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'Timestamp' property.
+     */
+    private final String timestamp;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'Livello Autenticazione' property.
+     */
+    private final int livelloAutenticazione;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity 'MAC' property.
+     */
+    private final String mac;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity internal representation.
+     */
+    private transient String internalRepresentation;
+
+    /**
+     * Constructor.<p>
+     * Builds an <code>IRIDE</code> <code>Digital Identity</code> entity
+     * out of an <code>IRIDE</code> <code>Digital Identity</code> string representation,
+     * which is first tokenized, with {@link IrideIdentityTokenizer#tokenize(String)},
+     * and then validated, with {@link IrideIdentityValidator#validate(String[])}.
+     *
+     * If the given <code>IRIDE</code> <code>Digital Identity</code> string representation value is {@code null}, then a {@link NullPointerException} is thrown.
+     *
+     * @see IrideIdentityTokenizer#tokenize(String)
+     * @see IrideIdentityValidator#validate(String[])
+     *
+     * @param irideDigitalIdentity <code>IRIDE</code> <code>Digital Identity</code> string representation
+     * @throws NullPointerException if the given <code>IRIDE</code> <code>Digital Identity</code> string representation value is {@code null}
+     * @throws IrideIdentityTokenizationException if any error occurs during tokenization or validation processes
+     */
+    public IrideIdentity(String irideDigitalIdentity) throws IrideIdentityTokenizationException {
+        this(TOKENIZER.tokenize(irideDigitalIdentity));
+    }
+
+    /**
+     * Constructor.<p>
+     * Builds an <code>IRIDE</code> <code>Digital Identity</code> entity
+     * out of the given <code>IRIDE</code> <code>Digital Identity</code> parameters,
+     * which are validated with {@link IrideIdentityValidator#validate(String[])}.
+     *
+     * @see IrideIdentityValidator#validate(String[])
+     *
+     * @param codFiscale <code>IRIDE</code> <code>Digital Identity</code> 'Codice Fiscale'
+     * @param nome <code>IRIDE</code> <code>Digital Identity</code> 'Nome'
+     * @param cognome <code>IRIDE</code> <code>Digital Identity</code> 'Cognome'
+     * @param idProvider <code>IRIDE</code> <code>Digital Identity</code> 'IdProvider'
+     * @param timestamp <code>IRIDE</code> <code>Digital Identity</code> 'Timestamp'
+     * @param livelloAutenticazione <code>IRIDE</code> <code>Digital Identity</code> 'Livello Autenticazione'
+     * @param mac <code>IRIDE</code> <code>Digital Identity</code> 'MAC'
+     * @throws IrideIdentityTokenizationException if any error occurs during tokenization or validation processes
+     */
+    public IrideIdentity(String codFiscale, String nome, String cognome, String idProvider, String timestamp, int livelloAutenticazione, String mac) throws IrideIdentityTokenizationException {
+        this(new String[] { codFiscale, nome, cognome, idProvider, timestamp, String.valueOf(livelloAutenticazione), mac });
+    }
+
+    /**
+     * Constructor.<p>
+     * Builds an <code>IRIDE</code> <code>Digital Identity</code> entity
+     * out of the given <code>IRIDE</code> <code>Digital Identity</code> string representation tokens,
+     * which are validated with {@link IrideIdentityValidator#validate(String[])}.
+     *
+     * @see IrideIdentityValidator#validate(String[])
+     *
+     * @param tokens <code>IRIDE</code> <code>Digital Identity</code> string representation tokens
+     * @throws IllegalArgumentException if given tokens array length is not equal to the expected length,
+     *         which should be {@link IrideIdentityToken#values()} length
+     *         (i.e.: the number of tokens defined in {@link IrideIdentityToken} enum).<br />
+     *         {@code null} tokens array is considered of length 0.
+     * @throws IrideIdentityTokenizationException if any error occurs during tokenization or validation processes
+     */
+    public IrideIdentity(String... tokens) throws IrideIdentityTokenizationException {
+        final IrideIdentityInvalidTokenValue[] invalidTokens = VALIDATOR.validate(tokens);
+        if (ArrayUtils.isNotEmpty(invalidTokens)) {
+            throw new IrideIdentityInvalidTokensException(invalidTokens);
+        }
+
+        this.codFiscale            = tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()];
+        this.nome                  = tokens[IrideIdentityToken.NOME.getPosition()];
+        this.cognome               = tokens[IrideIdentityToken.COGNOME.getPosition()];
+        this.idProvider            = tokens[IrideIdentityToken.ID_PROVIDER.getPosition()];
+        this.timestamp             = tokens[IrideIdentityToken.TIMESTAMP.getPosition()];
+        this.livelloAutenticazione = Integer.valueOf(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]);
+        this.mac                   = tokens[IrideIdentityToken.MAC.getPosition()];
+
+        this.internalRepresentation = null;
+    }
+
+    /**
+     * Utility method to parse an <code>IRIDE</code> <code>Digital Identity</code> string representation,
+     * returning an <code>IRIDE</code> <code>Digital Identity</code> entity if the given string value
+     * represents a valid <code>IRIDE</code> <code>Digital Identity</code>, {@code null} otherwise.
+     *
+     * @param irideDigitalIdentity an <code>IRIDE</code> <code>Digital Identity</code> string representation
+     * @return an <code>IRIDE</code> <code>Digital Identity</code> entity if the given string value
+     *         represents a valid <code>IRIDE</code> <code>Digital Identity</code>, {@code null} otherwise
+     */
+    public static IrideIdentity parseIrideIdentity(String irideDigitalIdentity) {
+        IrideIdentity irideIdentity = null;
+        try {
+            irideIdentity = new IrideIdentity(StringUtils.defaultString(irideDigitalIdentity));
+        } catch (IrideIdentityTokenizationException e) {
+            LOGGER.warning("IRIDE Identity tokenization error: " + e.getMessage());
+        }
+
+        return irideIdentity;
+    }
+
+    /**
+     * Utility method to validate an <code>IRIDE</code> <code>Digital Identity</code> string representation,
+     * returning {@code true} if the given string value represents a valid <code>IRIDE</code> <code>Digital Identity</code>,
+     * {@code false} otherwise.
+     *
+     * @param irideDigitalIdentity an <code>IRIDE</code> <code>Digital Identity</code> string representation
+     * @return {@code true} if the given string value represents a valid <code>IRIDE</code> <code>Digital Identity</code>,
+     *         {@code false} otherwise
+     */
+    public static boolean isValidIrideIdentity(String irideDigitalIdentity) {
+        if (StringUtils.isEmpty(irideDigitalIdentity)) {
+            return false;
+        }
+
+        try {
+            final IrideIdentityInvalidTokenValue[] invalidTokens = VALIDATOR.validate(
+                TOKENIZER.tokenize(irideDigitalIdentity)
+            );
+
+            if (ArrayUtils.isEmpty(invalidTokens)) {
+                return true;
+            } else {
+                LOGGER.warning(Utils.toString(invalidTokens));
+
+                return false;
+            }
+        } catch (IrideIdentityTokenizationException e) {
+            LOGGER.warning("IRIDE Identity tokenization error: " + e.getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * Utility method to validate an <code>IRIDE</code> <code>Digital Identity</code> string representation,
+     * returning {@code true} if the given string value <em>does not</em> represent a valid <code>IRIDE</code> <code>Digital Identity</code>,
+     * {@code false} otherwise.
+     *
+     * @param irideDigitalIdentity an <code>IRIDE</code> <code>Digital Identity</code> string representation
+     * @return {@code true} if the given string value <em>does not</em> represent a valid <code>IRIDE</code> <code>Digital Identity</code>,
+     *         {@code false} otherwise
+     */
+    public static boolean isNotValidIrideIdentity(String irideDigitalIdentity) {
+        return ! isValidIrideIdentity(irideDigitalIdentity);
+    }
+
+    /**
+     * @return the codFiscale
+     */
+    public String getCodFiscale() {
+        return this.codFiscale;
+    }
+
+    /**
+     * @return the nome
+     */
+    public String getNome() {
+        return this.nome;
+    }
+
+    /**
+     * @return the cognome
+     */
+    public String getCognome() {
+        return this.cognome;
+    }
+
+    /**
+     * @return the idProvider
+     */
+    public String getIdProvider() {
+        return this.idProvider;
+    }
+
+    /**
+     * @return the timestamp
+     */
+    public String getTimestamp() {
+        return this.timestamp;
+    }
+
+    /**
+     * @return the livelloAutenticazione
+     */
+    public int getLivelloAutenticazione() {
+        return this.livelloAutenticazione;
+    }
+
+    /**
+     * @return the mac
+     */
+    public String getMac() {
+        return this.mac;
+    }
+
+    /**
+     * Build and return the internal representation, as a string, of this {@link IrideIdentity} instance.
+     *
+     * @return the internal representation, as a string, of this given {@link IrideIdentity} instance
+     */
+    public String toInternalRepresentation() {
+        if (this.internalRepresentation == null) {
+            this.internalRepresentation = FORMATTER.format(this, FormatStyle.INTERNAL_REPRESENTATION);
+        }
+
+        return this.internalRepresentation;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    @Override
+    public int compareTo(IrideIdentity other) {
+        // quick test
+        if (this == other) {
+            return 0;
+        }
+
+        final CompareToBuilder builder = new CompareToBuilder();
+        builder.append(this.codFiscale, other.codFiscale)
+               .append(this.nome, other.nome)
+               .append(this.cognome, other.cognome)
+               .append(this.idProvider, other.idProvider)
+               .append(this.timestamp, other.timestamp)
+               .append(this.livelloAutenticazione, other.livelloAutenticazione)
+               .append(this.mac, other.mac);
+
+        return builder.toComparison();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final HashCodeBuilder builder = new HashCodeBuilder();
+        builder.append(this.codFiscale)
+               .append(this.nome)
+               .append(this.cognome)
+               .append(this.idProvider)
+               .append(this.timestamp)
+               .append(this.livelloAutenticazione)
+               .append(this.mac);
+
+        return builder.toHashCode();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final IrideIdentity other = (IrideIdentity) obj;
+
+        final EqualsBuilder builder = new EqualsBuilder();
+        builder.append(this.codFiscale, other.codFiscale)
+               .append(this.nome, other.nome)
+               .append(this.cognome, other.cognome)
+               .append(this.idProvider, other.idProvider)
+               .append(this.timestamp, other.timestamp)
+               .append(this.livelloAutenticazione, other.livelloAutenticazione)
+               .append(this.mac, other.mac);
+
+        return builder.isEquals();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return FORMATTER.format(this, FormatStyle.TO_STRING_REPRESENTATION);
+    }
+
+    /**
+     * Serializes this {@link IrideIdentity} instance.
+     *
+     * @return a new {@link SerializationProxy} for this {@link IrideIdentity} instance
+     */
+    private Object writeReplace() {
+        return new SerializationProxy(this);
+    }
+
+    /**
+     * Prevents deserialization attempts outside of the serialization proxy pattern.
+     *
+     * @param object
+     */
+    private void readObject(ObjectInputStream object) {
+        throw new IrideEntitySerializationException("Serialization Proxy required!");
+    }
+
+    /**
+     * Serialization proxy class for <code>IRIDE</code> <code>Digital Identity</code> entities.
+     *
+     * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+     *
+     * @see the <em>Serialization Proxy Pattern</em> as described in
+     *      Joshua Bloch's "Effective Java, (2n Edition)", Item 78: Consider serialization proxies instead of serialized instances
+     */
+    private static final class SerializationProxy implements Serializable {
+
+        private static final long serialVersionUID = -7526003150371224025L;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'Codice Fiscale' property.
+         */
+        private final String codFiscale;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'Nome' property.
+         */
+        private final String nome;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'Cognome' property.
+         */
+        private final String cognome;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'IdProvider' property.
+         */
+        private final String idProvider;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'Timestamp' property.
+         */
+        private final String timestamp;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'Livello Autenticazione' property.
+         */
+        private final int livelloAutenticazione;
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> entity 'MAC' property.
+         */
+        private final String mac;
+
+        /**
+         * Constructor.
+         *
+         * @param irideIdentity {@link IrideIdentity} instance to serialize
+         */
+        public SerializationProxy(IrideIdentity irideIdentity) {
+            this.codFiscale            = irideIdentity.codFiscale;
+            this.nome                  = irideIdentity.nome;
+            this.cognome               = irideIdentity.cognome;
+            this.idProvider            = irideIdentity.idProvider;
+            this.timestamp             = irideIdentity.timestamp;
+            this.livelloAutenticazione = irideIdentity.livelloAutenticazione;
+            this.mac                   = irideIdentity.mac;
+        }
+
+        /**
+         * Deserializes a new {@link IrideIdentity} instance.
+         *
+         * @return a new {@link IrideIdentity} instance
+         *
+         * @throws IrideIdentityApplicationException
+         */
+        private Object readResolve() {
+            try {
+                return new IrideIdentity(this.codFiscale, this.nome, this.cognome, this.idProvider, this.timestamp, this.livelloAutenticazione, this.mac);
+            } catch (IrideIdentityTokenizationException e) {
+                throw new IrideEntitySerializationException("An error occured during deserialization", e);
+            }
+        }
+
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideInfoPersona.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideInfoPersona.java
@@ -1,0 +1,253 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity;
+
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.geoserver.security.iride.entity.exception.IrideEntitySerializationException;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+/**
+ * <code>IRIDE</code> <code>InfoPersona</code> entity.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideInfoPersona implements Comparable<IrideInfoPersona>, Serializable {
+
+    private static final long serialVersionUID = 9084698382501836487L;
+
+    /**
+     * <code>IRIDE</code> <code>InfoPersona</code> string representation.
+     */
+    private static final String TO_STRING_FORMAT = "InfoPersona[%s,%s]";
+
+    /**
+     * <code>IRIDE</code> Role entity.
+     */
+    private final IrideRole role;
+
+    /**
+     * <code>InfoPersona</code> properties,
+     * expressed as an <em><a href="http://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ImmutableMap.html">immutable</a></em> {@link Map} instance.
+     */
+    private final ImmutableMap<String, Object> properties;
+
+    /**
+     * Constructor.
+     *
+     * @param role <code>IRIDE</code> Role entity
+     */
+    public IrideInfoPersona(IrideRole role) {
+        this(role, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param role
+     * @param properties
+     */
+    public IrideInfoPersona(IrideRole role, final Properties properties) {
+        this(role, Maps.toMap(
+            properties.stringPropertyNames(),
+            new Function<String, Object>() {
+                /*
+                 * (non-Javadoc)
+                 * @see com.google.common.base.Function#apply(java.lang.Object)
+                 */
+                @Override
+                public Object apply(String key) {
+                    return properties.getProperty(key);
+                }
+            })
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param role <code>IRIDE</code> Role entity
+     * @param properties <code>InfoPersona</code> properties
+     */
+    public IrideInfoPersona(IrideRole role, Map<String, Object> properties) {
+        Preconditions.checkArgument(role != null);
+
+        this.role       = role;
+        this.properties = properties == null
+            ? ImmutableMap.<String, Object>of()
+            : ImmutableMap.copyOf(properties);
+    }
+
+    /**
+     * Get the <code>IRIDE</code> Role entity object.
+     *
+     * @return the <code>IRIDE</code> Role entity object
+     */
+    public IrideRole getRole() {
+        return this.role;
+    }
+
+    /**
+     * Get the <code>InfoPersona</code> properties.
+     * The returned {@link Map} instance is <em><a href="http://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ImmutableMap.html">immutable</a></em>.
+     *
+     * @return the <code>InfoPersona</code> properties
+     */
+    public Map<String, Object> getProperties() {
+        return this.properties;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    @Override
+    public int compareTo(IrideInfoPersona other) {
+        // quick test
+        if (this == other) {
+            return 0;
+        }
+
+        final CompareToBuilder builder = new CompareToBuilder();
+        builder.append(this.role, other.role);
+
+        return builder.toComparison();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final HashCodeBuilder builder = new HashCodeBuilder();
+        builder.append(this.role);
+
+        return builder.toHashCode();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final IrideInfoPersona other = (IrideInfoPersona) obj;
+
+        final EqualsBuilder builder = new EqualsBuilder();
+        builder.append(this.role, other.role);
+
+        return builder.isEquals();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return String.format(TO_STRING_FORMAT, this.role, this.properties);
+    }
+
+    /**
+     * Serializes this {@link IrideInfoPersona} instance.
+     *
+     * @return a new {@link SerializationProxy} for this {@link IrideInfoPersona} instance
+     */
+    private Object writeReplace() {
+        return new SerializationProxy(this);
+    }
+
+    /**
+     * Prevents deserialization attempts outside of the serialization proxy pattern.
+     *
+     * @param object
+     */
+    private void readObject(ObjectInputStream object) {
+        throw new IrideEntitySerializationException("Serialization Proxy required!");
+    }
+
+    /**
+     * Serialization proxy class for <code>InfoPersona</code> entities.
+     *
+     * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+     *
+     * @see the <em>Serialization Proxy Pattern</em> as described in
+     *      Joshua Bloch's "Effective Java, (2n Edition)", Item 78: Consider serialization proxies instead of serialized instances
+     */
+    private static final class SerializationProxy implements Serializable {
+
+        private static final long serialVersionUID = 205794044832146769L;
+
+        /**
+         * <code>IRIDE</code> Role entity.
+         */
+        private final IrideRole role;
+
+        /**
+         * <code>InfoPersona</code> properties,
+         * expressed as an <em><a href="http://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/ImmutableMap.html">immutable</a></em> {@link Map} instance.
+         */
+        private final ImmutableMap<String, Object> properties;
+
+        /**
+         * Constructor.
+         *
+         * @param infoPersona {@link IrideInfoPersona} instance to serialize
+         */
+        public SerializationProxy(IrideInfoPersona infoPersona) {
+            this.role       = infoPersona.role;
+            this.properties = infoPersona.properties == null
+                ? ImmutableMap.<String, Object>of()
+                : ImmutableMap.copyOf(infoPersona.properties);
+        }
+
+        /**
+         * Deserializes a new {@link IrideInfoPersona} instance.
+         *
+         * @return a new {@link IrideInfoPersona} instance
+         */
+        private Object readResolve() {
+            return new IrideInfoPersona(this.role, this.properties);
+        }
+
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideRole.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideRole.java
@@ -1,0 +1,251 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity;
+
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.geoserver.security.iride.entity.exception.IrideEntitySerializationException;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * <code>IRIDE</code> Role entity.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideRole implements Comparable<IrideRole>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * <code>IRIDE</code> Role tokens separator: the "@" string.
+     */
+    private static final String SEPARATOR = "@";
+
+    /**
+     * <code>IRIDE</code> Role mnemonic string representation format.
+     */
+    private static final String TO_STRING_FORMAT = "%s" + SEPARATOR + "%s";
+
+    /**
+     * <code>IRIDE</code> Role code.
+     */
+    private final String code;
+
+    /**
+     * <code>IRIDE</code> Role domain code.
+     */
+    private final String domain;
+
+    /**
+     * Constructor.
+     *
+     * @param code <code>IRIDE</code> Role code
+     * @param domain <code>IRIDE</code> Role domain code
+     * @throws IllegalArgumentException if code or domain are either {@code null}
+     *         or empty (as per {@link StringUtils#isEmpty(String)}) strings
+     */
+    public IrideRole(String code, String domain) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(code));
+        Preconditions.checkArgument(StringUtils.isNotBlank(domain));
+
+        this.code   = StringUtils.upperCase(code);
+        this.domain = StringUtils.upperCase(domain);
+    }
+
+    /**
+     * Utility method to parse an <code>IRIDE</code> Role mnemonic string representation.<br />
+     * It accepts a mnemonic string representation, expressed with the following format: <code>"role code{@link #SEPARATOR}domain code"</code>.
+     *
+     * @param mnemonic <code>IRIDE</code> Role mnemonic string representation
+     * @return an <code>IRIDE</code> Role entity object
+     * @throws IllegalArgumentException if the given mnemonic string representation is not in the expected format
+     */
+    public static IrideRole parseRole(String mnemonic) {
+        final String[] tokens = StringUtils.splitByWholeSeparator(mnemonic, SEPARATOR);
+        if (ArrayUtils.getLength(tokens) != 2) {
+            throw new IllegalArgumentException(mnemonic);
+        }
+
+        return new IrideRole(tokens[0], tokens[1]);
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role code.
+     *
+     * @return the <code>IRIDE</code> Role code
+     */
+    public String getCode() {
+        return this.code;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role domain code.
+     *
+     * @return the <code>IRIDE</code> Role domain code
+     */
+    public String getDomain() {
+        return this.domain;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role mnemonic string representation.
+     *
+     * @return <code>IRIDE</code> Role mnemonic string representation
+     */
+    public String toMnemonicRepresentation() {
+        return String.format(TO_STRING_FORMAT, this.code, this.domain);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    @Override
+    public int compareTo(IrideRole other) {
+        // quick test
+        if (this == other) {
+            return 0;
+        }
+
+        final CompareToBuilder builder = new CompareToBuilder();
+        builder.append(this.code, this.domain);
+
+        return builder.toComparison();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final HashCodeBuilder builder = new HashCodeBuilder();
+        builder.append(this.code)
+               .append(this.domain);
+
+        return builder.toHashCode();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final IrideRole other = (IrideRole) obj;
+
+        final EqualsBuilder builder = new EqualsBuilder();
+        builder.append(this.code, other.code)
+               .append(this.domain, other.domain);
+
+        return builder.isEquals();
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role mnemonic string representation.
+     *
+     * @see #toMnemonicRepresentation()
+     * @return <code>IRIDE</code> Role mnemonic string representation
+     */
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.toMnemonicRepresentation();
+    }
+
+    /**
+     * Serializes this {@link IrideRole} instance.
+     *
+     * @return a new {@link SerializationProxy} for this {@link IrideRole} instance
+     */
+    private Object writeReplace() {
+        return new SerializationProxy(this);
+    }
+
+    /**
+     * Prevents deserialization attempts outside of the serialization proxy pattern.
+     *
+     * @param object
+     */
+    private void readObject(ObjectInputStream object) {
+        throw new IrideEntitySerializationException("Serialization Proxy required!");
+    }
+
+    /**
+     * Serialization proxy class for <code>IrideRole</code> entities.
+     *
+     * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+     *
+     * @see the <em>Serialization Proxy Pattern</em> as described in
+     *      Joshua Bloch's "Effective Java, (2n Edition)", Item 78: Consider serialization proxies instead of serialized instances
+     */
+    private static final class SerializationProxy implements Serializable {
+
+        private static final long serialVersionUID = 8879255647718171571L;
+
+        /**
+         * <code>IRIDE</code> Role code.
+         */
+        private final String code;
+
+        /**
+         * <code>IRIDE</code> Role domain code.
+         */
+        private final String domain;
+
+        /**
+         * Constructor.
+         *
+         * @param role {@link IrideRole} instance to serialize
+         */
+        public SerializationProxy(IrideRole role) {
+            this.code   = role.code;
+            this.domain = role.domain;
+        }
+
+        /**
+         * Deserializes a new {@link IrideRole} instance.
+         *
+         * @return a new {@link IrideRole} instance
+         */
+        private Object readResolve() {
+            return new IrideRole(this.code, this.domain);
+        }
+
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideUseCase.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideUseCase.java
@@ -1,0 +1,147 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+/**
+ * <code>IRIDE</code> <code>UseCase</code> entity.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideUseCase {
+
+    /**
+     * <code>IRIDE</code> <code>UseCase</code> string representation.
+     */
+    private static final String TO_STRING_FORMAT = "UseCase[%s,%s]";
+
+    /**
+     * Application.
+     */
+    private IrideApplication appId;
+
+    /**
+     * Use Case id.
+     */
+    private String id;
+
+    /**
+     * Constructor.
+     */
+    public IrideUseCase() {
+        /* NOP */
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param applicationId
+     * @param id
+     */
+    public IrideUseCase(String applicationId, String id) {
+        this(new IrideApplication(applicationId), id);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param applicationId
+     * @param id
+     */
+    public IrideUseCase(IrideApplication applicationId, String id) {
+        this.appId = applicationId;
+        this.id = id;
+    }
+
+    /**
+     * @return the applicationId
+     */
+    public IrideApplication getAppId() {
+        return this.appId;
+    }
+
+    /**
+     * @param appId the applicationId to set
+     */
+    public void setAppId(IrideApplication appId) {
+        this.appId = appId;
+    }
+
+    /**
+     * @return the id
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        final HashCodeBuilder builder = new HashCodeBuilder();
+        builder.append(this.appId)
+               .append(this.id);
+
+        return builder.toHashCode();
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        final IrideUseCase other = (IrideUseCase) obj;
+
+        final EqualsBuilder builder = new EqualsBuilder();
+        builder.append(this.appId, other.appId)
+               .append(this.id, other.id);
+
+        return builder.isEquals();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return String.format(TO_STRING_FORMAT, this.appId, this.id);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/exception/IrideEntitySerializationException.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/exception/IrideEntitySerializationException.java
@@ -1,0 +1,49 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.exception;
+
+/**
+ * <code>IRIDE</code> entity object serialization exception class.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideEntitySerializationException extends RuntimeException {
+
+    private static final long serialVersionUID = 4001069701076979150L;
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     */
+    public IrideEntitySerializationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     * @param cause
+     */
+    public IrideEntitySerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityFormatter.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityFormatter.java
@@ -1,0 +1,133 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity;
+
+import org.geoserver.security.iride.entity.IrideIdentity;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> formatter.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityFormatter {
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity formatting styles.
+     *
+     * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+     */
+    public enum FormatStyle {
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> internal representation.
+         */
+        INTERNAL_REPRESENTATION {
+
+            /**
+             * Format the given {@link IrideIdentity} instance returning an <code>IRIDE</code> <code>Digital Identity</code> internal representation,
+             * with the following format: {@link IrideIdentity#getCodFiscale()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getNome()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getCognome()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getIdProvider()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getTimestamp()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getLivelloAutenticazione()} + {@link IrideIdentityToken#SEPARATOR}.
+             */
+            /*
+             * (non-Javadoc)
+             * @see org.geoserver.security.iride.entity.IrideIdentityFormatter.FormatStyle#format(org.geoserver.security.iride.entity.IrideIdentity)
+             */
+            @Override
+            String format(IrideIdentity irideIdentity) {
+                final StringBuilder builder = new StringBuilder();
+                builder.append(irideIdentity.getCodFiscale()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getNome()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getCognome()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getIdProvider()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getTimestamp()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getLivelloAutenticazione());
+
+                return builder.toString();
+            }
+
+        },
+
+        /**
+         * <code>IRIDE</code> <code>Digital Identity</code> <code>toString</code> representation.
+         */
+        TO_STRING_REPRESENTATION {
+
+            /**
+             * Format the given {@link IrideIdentity} instance returning an <code>IRIDE</code> <code>Digital Identity</code> internal representation,
+             * with the following format: {@link IrideIdentity#getCodFiscale()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getNome()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getCognome()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getIdProvider()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getTimestamp()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getLivelloAutenticazione()} + {@link IrideIdentityToken#SEPARATOR}
+             *                            {@link IrideIdentity#getMac()}.
+             */
+            /*
+             * (non-Javadoc)
+             * @see org.geoserver.security.iride.entity.IrideIdentityFormatter.FormatStyle#format(org.geoserver.security.iride.entity.IrideIdentity)
+             */
+            @Override
+            String format(IrideIdentity irideIdentity) {
+                final StringBuilder builder = new StringBuilder();
+                builder.append(irideIdentity.getCodFiscale()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getNome()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getCognome()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getIdProvider()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getTimestamp()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getLivelloAutenticazione()).append(IrideIdentityToken.SEPARATOR)
+                       .append(irideIdentity.getMac());
+
+                return builder.toString();
+            }
+
+        },
+        ;
+
+        /**
+         * Returns the formatted representation of the given <code>IRIDE</code> <code>Digital Identity</code> entity.
+         *
+         * @param irideIdentity the <code>IRIDE</code> <code>Digital Identity</code> entity to format
+         * @return the formatted representation of the given <code>IRIDE</code> <code>Digital Identity</code> entity
+         */
+        abstract String format(IrideIdentity irideIdentity);
+    }
+
+    /**
+     * Returns the formatted representation of the given <code>IRIDE</code> <code>Digital Identity</code> entity
+     * as per given {@link FormatStyle}, or {@code null} if no {@link FormatStyle} is given.
+     *
+     * @param irideIdentity <code>IRIDE</code> <code>Digital Identity</code> entity object to format
+     * @param style the given {@link FormatStyle}
+     * @return the formatted representation of the given <code>IRIDE</code> <code>Digital Identity</code> entity
+     *         as per given {@link FormatStyle}, or {@code null} if no {@link FormatStyle} is given
+     */
+    public String format(IrideIdentity irideIdentity, FormatStyle style) {
+        if (irideIdentity == null || style == null) {
+            return null;
+        }
+
+        return style.format(irideIdentity);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityTokenizer.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityTokenizer.java
@@ -1,0 +1,111 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityMissingTokenException;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityMissingTokenValue;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> tokenizer.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityTokenizer {
+
+    /**
+     * Tokenize the given string value that should represents an <code>IRIDE</code> <code>Digital Identity</code>.<p>
+     * A successful tokenization should return a string array composed of <em>exactly</em> {@link IrideIdentityToken#values()} length elements.<p>
+     * If the given string value is {@code null}, then a {@link NullPointerException} is thrown.
+     *
+     * @param value a string value that should represents an <code>IRIDE</code> <code>Digital Identity</code>
+     * @return <code>IRIDE</code> <code>Digital Identity</code> tokens.
+     *         A successful tokenization should return a string array composed of <em>exactly</em> {@link IrideIdentityToken#values()} elements
+     * @throws NullPointerException if the given string value is {@code null}
+     * @throws IrideIdentityMissingTokenException a specialized <code>IrideIdentityTokenizationException</code> thrown as soon as
+     *         any one of the seven expected tokens is not found in the tokenized string value
+     */
+    public String[] tokenize(String value) throws IrideIdentityMissingTokenException {
+        final List<String> tokens = new ArrayList<>();
+
+        // 1) 'Codice Fiscale' token
+        int i1 = value.indexOf(IrideIdentityToken.SEPARATOR);
+        if (i1 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.CODICE_FISCALE, value);
+        }
+        tokens.add(value.substring(0, i1));
+
+        // 2) 'Nome' token
+        int i2 = value.indexOf(IrideIdentityToken.SEPARATOR, i1 + 1);
+        if (i2 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.NOME, value);
+        }
+        tokens.add(value.substring(i1 + 1, i2));
+
+        // 3) 'Cognome' token
+        int i3 = value.indexOf(IrideIdentityToken.SEPARATOR, i2 + 1);
+        if (i3 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.COGNOME, value);
+        }
+        tokens.add(value.substring(i2 + 1, i3));
+
+        // 4) 'IdProvider' token
+        int i4 = value.indexOf(IrideIdentityToken.SEPARATOR, i3 + 1);
+        if (i4 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.ID_PROVIDER, value);
+        }
+        tokens.add(value.substring(i3 + 1, i4));
+
+        // 5) 'Timestamp' token
+        int i5 = value.indexOf(IrideIdentityToken.SEPARATOR, i4 + 1);
+        if (i5 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.TIMESTAMP, value);
+        }
+        tokens.add(value.substring(i4 + 1, i5));
+
+        // 6) 'Livello Autenticazione' token
+        int i6 = value.indexOf(IrideIdentityToken.SEPARATOR, i5 + 1);
+        if (i6 == -1) {
+            throw newMissingTokenException(IrideIdentityToken.LIVELLO_AUTENTICAZIONE, value);
+        }
+        tokens.add(value.substring(i5 + 1, i6));
+
+        // 7) 'MAC' token
+        if (value.length() <= i6 + 1) {
+            throw newMissingTokenException(IrideIdentityToken.MAC, value);
+        }
+        tokens.add(value.substring(i6 + 1));
+
+        return tokens.toArray(new String[tokens.size()]);
+    }
+
+    /**
+     *
+     * @param token
+     * @param value
+     * @return
+     */
+    private static IrideIdentityMissingTokenException newMissingTokenException(IrideIdentityToken token, String value) {
+        return new IrideIdentityMissingTokenException(new IrideIdentityMissingTokenValue(token, value));
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityValidator.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityValidator.java
@@ -1,0 +1,324 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
+import org.geoserver.security.iride.entity.util.logging.LoggerProvider;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> validator.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityValidator {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerProvider.ENTITY.getLogger();
+
+    private static final Pattern FISCAL_CODE_WEAK_VALIDATION_PATTERN = Pattern.compile("^[A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z]$");
+
+    private static final Pattern FISCAL_CODE_STRONG_VALIDATION_PATTERN = Pattern.compile("^(?:[B-DF-HJ-NP-TV-Z](?:[AEIOU]{2}|[AEIOU]X)|[AEIOU]{2}X|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[1256LMRS][\\dLMNP-V])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[\\dLMNP-V][1-9MNP-V]|[1-9MNP-V][0L]))[A-Z]$");
+
+    private static final Integer[] IRIDE_AUTHENTICATION_LEVELS = new Integer[] { 1, 2, 4, 8, 16 };
+
+    private static final int MAC_LENGTH = 24;
+
+    /**
+     * {@link DateFormat} instance.
+     */
+    private final DateFormat dateFormat;
+
+    /**
+     * Constructor.
+     */
+    public IrideIdentityValidator() {
+        this.dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+        this.dateFormat.setCalendar(Calendar.getInstance(Locale.ITALY));
+        this.dateFormat.setLenient(false);
+    }
+
+    /**
+     *
+     * @param tokens
+     * @return
+     */
+    public IrideIdentityInvalidTokenValue[] validate(String... tokens) {
+        LOGGER.finest("IRIDE Identity tokens: " + Arrays.toString(tokens));
+
+        this.checkTokens(tokens);
+
+        final List<IrideIdentityInvalidTokenValue> invalidTokenValues = new ArrayList<>();
+
+        // Check "codice fiscale" token
+        if (this.isNotValidCodiceFiscale(tokens[0])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.CODICE_FISCALE, tokens[0]);
+        }
+
+        // Check "nome" token
+        if (this.isNotValidNome(tokens[1])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.NOME, tokens[1]);
+        }
+
+        // Check "cognome" token
+        if (this.isNotValidCognome(tokens[2])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.COGNOME, tokens[2]);
+        }
+
+        // Check "idProvider" token
+        if (this.isNotValidIdProvider(tokens[3])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.ID_PROVIDER, tokens[3]);
+        }
+
+        // Check "timestamp" token
+        if (this.isNotValidTimestamp(tokens[4])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.TIMESTAMP, tokens[4]);
+        }
+
+        // Check "livelloAutenticazione" token
+        if (this.isNotValidLivelloAutenticazione(tokens[5])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.LIVELLO_AUTENTICAZIONE, tokens[5]);
+        }
+
+        // Check "mac" token
+        if (this.isNotValidMac(tokens[6])) {
+            addInvalidTokenValue(invalidTokenValues, IrideIdentityToken.MAC, tokens[6]);
+        }
+
+        return invalidTokenValues.toArray(new IrideIdentityInvalidTokenValue[invalidTokenValues.size()]);
+    }
+
+    /**
+     *
+     * @param invalidTokenValues
+     * @param token
+     * @param value
+     */
+    private static void addInvalidTokenValue(List<IrideIdentityInvalidTokenValue> invalidTokenValues, IrideIdentityToken token, String value) {
+        invalidTokenValues.add(new IrideIdentityInvalidTokenValue(token, value, null));
+    }
+
+    /**
+     * Check that the given tokens length equals the expected length, which should be {@link IrideIdentityToken#values()} length
+     * (i.e.: the number of tokens defined in {@link IrideIdentityToken} enum).<br />
+     * {@code null} tokens array is considered of length 0.<p>
+     * If not so, an {@link IllegalArgumentException} is thrown, detailing the given tokens length vs the expected one.
+     *
+     * @param tokens the given tokens array to check for valid length
+     */
+    private void checkTokens(String[] tokens) {
+        final int expectedTokenLength = IrideIdentityToken.values().length;
+
+        if (ArrayUtils.getLength(tokens) != expectedTokenLength) {
+            throw new IllegalArgumentException(
+                "Tokens array length is " + ArrayUtils.getLength(tokens) +
+                " instead of the expected mandatory length of " + expectedTokenLength + " elements."
+            );
+        }
+    }
+
+    /**
+     * Validates <code>Codice Fiscale</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidCodiceFiscale(String value) {
+        return ! this.isValidCodiceFiscale(value);
+    }
+
+    /**
+     * Validates <code>Codice Fiscale</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidCodiceFiscale(String value) {
+        if (StringUtils.isBlank(value)) {
+            return false;
+        }
+
+        if (! FISCAL_CODE_STRONG_VALIDATION_PATTERN.matcher(value).matches() &&
+            ! FISCAL_CODE_WEAK_VALIDATION_PATTERN.matcher(value).matches()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates <code>Nome</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidNome(String value) {
+        return ! this.isValidNome(value);
+    }
+
+    /**
+     * Validates <code>Nome</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidNome(String value) {
+        return StringUtils.isNotBlank(value);
+    }
+
+    /**
+     * Validates <code>Cognome</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidCognome(String value) {
+        return ! this.isValidCognome(value);
+    }
+
+    /**
+     * Validates <code>Cognome</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidCognome(String value) {
+        return StringUtils.isNotBlank(value);
+    }
+
+    /**
+     * Validates <code>IdProvider</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidIdProvider(String value) {
+        return ! this.isValidIdProvider(value);
+    }
+
+    /**
+     * Validates <code>IdProvider</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidIdProvider(String value) {
+        return StringUtils.isNotBlank(value);
+    }
+
+    /**
+     * Validates <code>Timestamp</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidTimestamp(String value) {
+        return ! this.isValidTimestamp(value);
+    }
+
+    /**
+     * Validates <code>Timestamp</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidTimestamp(String value) {
+        if (value == null) {
+            return false;
+        }
+
+        try {
+            this.dateFormat.parse(value);
+
+            return true;
+        } catch (ParseException e) {
+            LOGGER.severe("Invalid date format: " + e.getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * Validates <code>livelloAutenticazione</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidLivelloAutenticazione(String value) {
+        return ! this.isValidLivelloAutenticazione(value);
+    }
+
+    /**
+     * Validates <code>livelloAutenticazione</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidLivelloAutenticazione(String value) {
+        try {
+            final Integer livello = NumberUtils.createInteger(value);
+            if (! ArrayUtils.contains(IRIDE_AUTHENTICATION_LEVELS, livello)) {
+                return false;
+            }
+
+            return true;
+        } catch (NumberFormatException e) {
+            LOGGER.severe("Invalid number format: " + e.getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * Validates <code>mac</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isNotValidMac(String value) {
+        return ! this.isValidMac(value);
+    }
+
+    /**
+     * Validates <code>mac</code> token.
+     *
+     * @param value
+     * @return
+     */
+    private boolean isValidMac(String value) {
+        return StringUtils.isNotBlank(value) && value.length() == MAC_LENGTH;
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityInvalidTokensException.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityInvalidTokensException.java
@@ -1,0 +1,99 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.exception;
+
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
+import org.geoserver.security.iride.entity.util.Constants;
+import org.geoserver.security.iride.entity.util.Utils;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> exception thrown for one or more <em>invalid</em> tokens.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityInvalidTokensException extends IrideIdentityTokenizationException {
+
+    private static final long serialVersionUID = -5732259205731098733L;
+
+    /**
+     * No invalid tokens specified.
+     */
+    private static final IrideIdentityInvalidTokenValue[] NO_INVALID_TOKENS_SPECIFIED = new IrideIdentityInvalidTokenValue[0];
+
+    /**
+     * The invalid tokens.
+     */
+    private final IrideIdentityInvalidTokenValue[] invalidTokens;
+
+    /**
+     * Constructor.
+     */
+    public IrideIdentityInvalidTokensException() {
+        this(
+            Constants.INVALID_TOKENS_EXCEPTION_MESSAGE_CAPTION,
+            NO_INVALID_TOKENS_SPECIFIED
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     */
+    public IrideIdentityInvalidTokensException(String message) {
+        this(
+            String.format(Constants.INVALID_TOKENS_GENERIC_EXCEPTION_MESSAGE, message),
+            NO_INVALID_TOKENS_SPECIFIED
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param invalidTokens the invalid tokens
+     */
+    public IrideIdentityInvalidTokensException(IrideIdentityInvalidTokenValue[] invalidTokens) {
+        this(
+            Utils.toString(Constants.INVALID_TOKENS_SPECIFIC_EXCEPTION_MESSAGE, invalidTokens),
+            invalidTokens
+        );
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     * @param invalidTokens2
+     */
+    private IrideIdentityInvalidTokensException(String message, IrideIdentityInvalidTokenValue[] invalidTokens) {
+        super(message);
+
+        this.invalidTokens = Utils.defaultToEmpty(invalidTokens);
+    }
+
+    /**
+     * Returns the invalid tokens, if any.
+     *
+     * @return the invalid tokens, if any
+     */
+    public IrideIdentityInvalidTokenValue[] getInvalidTokens() {
+        return this.invalidTokens;
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityMissingTokenException.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityMissingTokenException.java
@@ -1,0 +1,68 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.exception;
+
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityMissingTokenValue;
+import org.geoserver.security.iride.entity.util.Constants;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> exception thrown for any <em>missing</em> tokens.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityMissingTokenException extends IrideIdentityTokenizationException {
+
+    private static final long serialVersionUID = 2810994807986926520L;
+
+    /**
+     * The missing token.
+     */
+    private IrideIdentityMissingTokenValue missingTokenValue;
+
+    /**
+     * Constructor.
+     */
+    public IrideIdentityMissingTokenException() {
+        this(null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param missingToken the missing token
+     */
+    public IrideIdentityMissingTokenException(IrideIdentityMissingTokenValue missingToken) {
+        super(missingToken == null
+            ? Constants.MISSING_UNSPECIFIED_TOKEN_EXCEPTION_MESSAGE
+            : String.format(Constants.MISSING_TOKEN_EXCEPTION_MESSAGE, missingToken.getToken())
+        );
+
+        this.missingTokenValue = missingToken;
+    }
+
+    /**
+     * Returns the missing token.
+     *
+     * @return the missing token
+     */
+    public IrideIdentityMissingTokenValue getMissingTokenValue() {
+        return this.missingTokenValue;
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityTokenizationException.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/exception/IrideIdentityTokenizationException.java
@@ -1,0 +1,50 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.exception;
+
+import org.geoserver.security.iride.entity.util.Constants;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> base tokenization and validation processes exception class.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public class IrideIdentityTokenizationException extends Exception {
+
+    private static final long serialVersionUID = -2870022721604366580L;
+
+    /**
+     * Constructor.
+     *
+     * @param cause
+     */
+    public IrideIdentityTokenizationException(Throwable cause) {
+        super(String.format(Constants.INVALID_TOKENS_GENERIC_EXCEPTION_MESSAGE, "an error occured during tokenization"), cause);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     */
+    protected IrideIdentityTokenizationException(String message) {
+        super(message);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/package-info.java
@@ -1,0 +1,30 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> entity helper classes.
+ * <p>The helper classes are responsible for the following operations:
+ * <ul>
+ *   <li>Formatting ({@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter})</li>
+ *   <li>Tokenization ({@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer})</li>
+ *   <li>Validation ({@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator})</li>
+ * </ul>
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+package org.geoserver.security.iride.entity.identity;

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/IrideIdentityToken.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/IrideIdentityToken.java
@@ -1,0 +1,139 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.token;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> tokens.<p>
+ * For each token the following bits of information are given:
+ * <ul>
+ *   <li>its position in an <code>IRIDE</code> <code>Digital Identity</code> string representation</li>
+ *   <li>the name of the corresponding property in an <code>IRIDE</code> <code>Digital Identity</code> object</li>
+ *   <li>a simple description</li>
+ * </ul>
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public enum IrideIdentityToken {
+
+    /**
+     * 'Codice Fiscale' <code>IRIDE</code> <code>Digital Identity</code> 1st token.
+     */
+    CODICE_FISCALE(0, "codFiscale", "Codice Fiscale"),
+
+    /**
+     * 'Nome' <code>IRIDE</code> <code>Digital Identity</code> 2nd token.
+     */
+    NOME(1, "nome", "Nome"),
+
+    /**
+     * 'Cognome' <code>IRIDE</code> <code>Digital Identity</code> 3rd token.
+     */
+    COGNOME(2, "cognome", "Cognome"),
+
+    /**
+     * 'IdProvider' <code>IRIDE</code> <code>Digital Identity</code> 4th token.
+     */
+    ID_PROVIDER(3, "idProvider", "IdProvider"),
+
+    /**
+     * 'Timestamp' <code>IRIDE</code> <code>Digital Identity</code> 5th token.
+     */
+    TIMESTAMP(4, "timestamp", "Timestamp"),
+
+    /**
+     * 'Livello Autenticazione' <code>IRIDE</code> <code>Digital Identity</code> 6th token.
+     */
+    LIVELLO_AUTENTICAZIONE(5, "livelloAutenticazione", "Livello Autenticazione"),
+
+    /**
+     * 'MAC' <code>IRIDE</code> <code>Digital Identity</code> 7th token.
+     */
+    MAC(6, "mac", "MAC"),
+    ;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> tokens separator character.
+     */
+    public static final char SEPARATOR = '/';
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> token position.
+     */
+    private int position;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> token property name.
+     */
+    private String property;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> token description.
+     */
+    private String description;
+
+    /**
+     * Constructor.
+     *
+     * @param position <code>IRIDE</code> <code>Digital Identity</code> token position
+     * @param property <code>IRIDE</code> <code>Digital Identity</code> token property name
+     * @param description <code>IRIDE</code> <code>Digital Identity</code> token description
+     */
+    private IrideIdentityToken(int position, String property, String description) {
+        this.position    = position;
+        this.property    = property;
+        this.description = description;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> <code>Digital Identity</code> token position.
+     *
+     * @return the <code>IRIDE</code> <code>Digital Identity</code> token position
+     */
+    public int getPosition() {
+        return this.position;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> <code>Digital Identity</code> token property name.
+     *
+     * @return the <code>IRIDE</code> <code>Digital Identity</code> token property name
+     */
+    public String getProperty() {
+        return this.property;
+    }
+
+    /**
+     * Returns <code>IRIDE</code> <code>Digital Identity</code> token description.
+     *
+     * @return the <code>IRIDE</code> <code>Digital Identity</code> token description
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see java.lang.Enum#toString()
+     */
+    @Override
+    public String toString() {
+        return String.format("'%s' token, at position %d, for property %s", this.description, this.position, this.property);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/package-info.java
@@ -1,0 +1,24 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> tokens enumeration.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+package org.geoserver.security.iride.entity.identity.token;

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityInvalidTokenValue.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityInvalidTokenValue.java
@@ -1,0 +1,59 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.token.value;
+
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> placeholder object for any {@link IrideIdentityToken} instance with its associated <em>invalid<em> value and reason.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityInvalidTokenValue extends IrideIdentityTokenValue {
+
+	private static final long serialVersionUID = 2177838434198200734L;
+
+	/**
+     * The <code>IRIDE</code> <code>Digital Identity</code> token <em>invalid<em> value reason.
+     */
+    private final String reason;
+
+    /**
+     * Constructor.
+     *
+     * @param token the <code>IRIDE</code> <code>Digital Identity</code> token
+     * @param value the <code>IRIDE</code> <code>Digital Identity</code> token associated <em>invalid<em> value
+     * @param reason the <code>IRIDE</code> <code>Digital Identity</code> token associated <em>invalid<em> value reason
+     */
+    public IrideIdentityInvalidTokenValue(IrideIdentityToken token, String value, String reason) {
+        super(token, value);
+
+        this.reason = reason;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> <code>Digital Identity</code> token <em>invalid<em> value reason.
+     *
+     * @return the <code>IRIDE</code> <code>Digital Identity</code> token <em>invalid<em> value reason
+     */
+    public final String getReason() {
+        return this.reason;
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityMissingTokenValue.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityMissingTokenValue.java
@@ -1,0 +1,43 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.token.value;
+
+import org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> placeholder object for any missing token.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityMissingTokenValue extends IrideIdentityTokenValue {
+
+	private static final long serialVersionUID = 1173484239470646184L;
+
+	/**
+     * Constructor.
+     *
+     * @param token the <code>IRIDE</code> <code>Digital Identity</code> missing token
+     * @param value the candidate <code>IRIDE</code> <code>Digital Identity</code> string representation being tokenized by {@link IrideIdentityTokenizer}
+     */
+    public IrideIdentityMissingTokenValue(IrideIdentityToken token, String value) {
+        super(token, value);
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityTokenValue.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/IrideIdentityTokenValue.java
@@ -1,0 +1,73 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.identity.token.value;
+
+import java.io.Serializable;
+
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> object holding an {@link IrideIdentityToken} instance and an associated value.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public class IrideIdentityTokenValue implements Serializable {
+
+	private static final long serialVersionUID = -1469487295824004514L;
+
+	/**
+     * The <code>IRIDE</code> <code>Digital Identity</code> token.
+     */
+    private final IrideIdentityToken token;
+
+    /**
+     * The <code>IRIDE</code> <code>Digital Identity</code> token associated value.
+     */
+    private final String value;
+
+    /**
+     * Constructor.
+     *
+     * @param token the <code>IRIDE</code> <code>Digital Identity</code> token
+     * @param value the <code>IRIDE</code> <code>Digital Identity</code> token value
+     */
+    public IrideIdentityTokenValue(IrideIdentityToken token, String value) {
+        this.token = token;
+        this.value = value;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> <code>Digital Identity</code> token.
+     *
+     * @return the token
+     */
+    public final IrideIdentityToken getToken() {
+        return this.token;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> <code>Digital Identity</code> token value.
+     *
+     * @return the <code>IRIDE</code> <code>Digital Identity</code> token value
+     */
+    public final String getValue() {
+        return this.value;
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/package-info.java
@@ -1,0 +1,30 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> token value and related classes.
+ * <p> The token value class models the current value of a particular
+ * <code>IRIDE</code> <code>Digital Identity</code> token ({@link org.geoserver.security.iride.entity.identity.token.value.IrideIdentityTokenValue})
+ * <p>Related classes let describe the missing ({@link org.geoserver.security.iride.entity.identity.token.value.IrideIdentityMissingTokenValue}
+ * and invalid ({@link org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue}) token(s),
+ * disclosed during <code>IRIDE</code> <code>Digital Identity</code> tokenization (by {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer} class)
+ * and validation (by {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator} class) operations.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+package org.geoserver.security.iride.entity.identity.token.value;

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/package-info.java
@@ -1,0 +1,29 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/**
+ * <code>IRIDE</code> entities.
+ * <p>They all share the following traits:
+ * <ul>
+ *   <li>Serializability (as per <em>Serialization Proxy Pattern</em> as described in <a href="http://www.oracle.com/technetwork/articles/java/bloch-effective-08-qa-140880.html">Joshua Bloch's "Effective Java, (2n Edition)"</a>, Item 78)</li>
+ *   <li><a href="https://docs.oracle.com/javase/tutorial/essential/concurrency/immutable.html">Immutability</a></li>
+ * </ul>
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+package org.geoserver.security.iride.entity;

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/Constants.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/Constants.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin used for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -16,7 +16,7 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-package org.geoserver.security.iride.util;
+package org.geoserver.security.iride.entity.util;
 
 /**
  * Utility class for application constants.

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/Utils.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/Utils.java
@@ -1,0 +1,98 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.entity.util;
+
+import java.util.Arrays;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.Transformer;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> utilities.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class Utils {
+
+    /**
+     * Constructor.
+     */
+    private Utils() {
+        /* NOP */
+    }
+
+    /**
+     *
+     * @param array
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] defaultToEmpty(T[] array) {
+        return (T[]) ArrayUtils.nullToEmpty(array);
+    }
+
+    /**
+     *
+     * @param invalidTokenValues
+     * @return
+     */
+    public static String toString(IrideIdentityInvalidTokenValue... invalidTokenValues) {
+        return toString(Constants.INVALID_TOKENS_SPECIFIC_EXCEPTION_MESSAGE, invalidTokenValues);
+    }
+
+    /**
+     *
+     * @param invalidTokenValuesMessageTemplate
+     * @param invalidTokenValues
+     * @return
+     */
+    public static String toString(final String invalidTokenValuesMessageTemplate, IrideIdentityInvalidTokenValue... invalidTokenValues) {
+        return StringUtils.join(
+            CollectionUtils.collect(
+                Arrays.asList(defaultToEmpty(invalidTokenValues)),
+                new Transformer() {
+                    /*
+                     * (non-Javadoc)
+                     * @see org.apache.commons.collections.Transformer#transform(java.lang.Object)
+                     */
+                    @Override
+                    public String transform(Object input) {
+                        if (input == null) {
+                            return "";
+                        } else {
+                            final IrideIdentityInvalidTokenValue invalidToken = (IrideIdentityInvalidTokenValue) input;
+
+                            return String.format(
+                                invalidTokenValuesMessageTemplate,
+                                invalidToken.getToken(),
+                                String.valueOf(invalidToken.getValue())
+                            );
+                        }
+                    }
+                }
+            ),
+            SystemUtils.LINE_SEPARATOR
+        );
+    }
+
+}

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/logging/LoggerProvider.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/util/logging/LoggerProvider.java
@@ -16,12 +16,9 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-package org.geoserver.security.iride.util.logging;
+package org.geoserver.security.iride.entity.util.logging;
 
 import java.util.logging.Logger;
-
-import org.geoserver.security.iride.service.api.PolicyEnforcerBase;
-import org.geoserver.security.iride.service.api.PolicyEnforcerHelper;
 import org.geotools.util.logging.Logging;
 
 /**
@@ -32,28 +29,10 @@ import org.geotools.util.logging.Logging;
 public enum LoggerProvider {
 
     /**
-     * {@link Logger} used by all <a href="http://docs.geoserver.org/latest/en/developer/programming-guide/security/index.html#security-services">Security Services</a>.
-     */
-    SECURITY(
-        Logging.getLogger(Constants.LOGGER_BASE_NAME + ".security")
-    ),
-    /**
      * {@link Logger} used by all <code>IRIDE</code> entities (and related) objects.
      */
     ENTITY(
-        Logging.getLogger(Constants.LOGGER_BASE_NAME + ".entity")
-    ),
-    /**
-     * {@link Logger} used by {@link PolicyEnforcerBase} and {@link PolicyEnforcerHelper} instances.
-     */
-    POLICY(
-        Logging.getLogger(Constants.LOGGER_BASE_NAME + ".policy")
-    ),
-    /**
-     * {@link Logger} used by utility and/or helper classes.
-     */
-    UTIL(
-        Logging.getLogger(Constants.LOGGER_BASE_NAME + ".util")
+        Logging.getLogger("org.geoserver.security.iride.entity")
     ),
     ;
 
@@ -78,27 +57,6 @@ public enum LoggerProvider {
      */
     public Logger getLogger() {
         return this.logger;
-    }
-
-    /**
-     * Constants used by {@link LoggerProvider}.
-     *
-     * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
-     */
-    private static final class Constants {
-
-        /**
-         * {@link Logger} base name.
-         */
-        static final String LOGGER_BASE_NAME = "org.geoserver.security.iride";
-
-        /**
-         * Constructor.
-         */
-        private Constants() {
-            /* NOP */
-        }
-
     }
 
 }

--- a/security/iride-entities/src/main/resources/.gitignore
+++ b/security/iride-entities/src/main/resources/.gitignore
@@ -1,4 +1,0 @@
-# Hack to commit empty folder: ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/security/iride-entities/src/main/resources/.gitignore
+++ b/security/iride-entities/src/main/resources/.gitignore
@@ -1,0 +1,4 @@
+# Hack to commit empty folder: ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/security/iride-entities/src/test/java/.gitignore
+++ b/security/iride-entities/src/test/java/.gitignore
@@ -1,4 +1,0 @@
-# Hack to commit empty folder: ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/security/iride-entities/src/test/java/.gitignore
+++ b/security/iride-entities/src/test/java/.gitignore
@@ -1,0 +1,4 @@
+# Hack to commit empty folder: ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/Utils.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/Utils.java
@@ -1,0 +1,39 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride;
+
+/**
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class Utils {
+
+    /**
+     * A single space character string.
+     */
+    public static final String BLANK = " ";
+
+    /**
+     * Constructor.
+     */
+    private Utils() {
+        /* NOP */
+    }
+
+}

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/AllTests.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/AllTests.java
@@ -1,0 +1,46 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.identity;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * <code>IRIDE</code> Identity entity object, tokenization and validation <code>JUnit</code> Test Suite.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+@RunWith(Suite.class)
+@SuiteClasses({
+    IrideIdentityTest.class,
+    IrideIdentityFormatterTest.class,
+    IrideIdentityTokenizerTest.class,
+    IrideIdentityValidatorTest.class
+})
+public final class AllTests {
+
+    /**
+     * Constructor.
+     */
+    private AllTests() {
+        /* NOP */
+    }
+
+}

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
@@ -1,0 +1,172 @@
+/*
+ *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.identity;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+import org.geoserver.security.iride.entity.IrideIdentity;
+import org.geoserver.security.iride.entity.identity.IrideIdentityFormatter;
+import org.geoserver.security.iride.entity.identity.IrideIdentityFormatter.FormatStyle;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geotools.util.logging.Logging;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> entity formatter <code>JUnit</code> Test Case.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityFormatterTest {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logging.getLogger(IrideIdentityTest.class);
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> tokens.
+     */
+    private String[] tokens;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity instance.
+     */
+    private IrideIdentity irideIdentity;
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> entity formatter.
+     */
+    private IrideIdentityFormatter formatter;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        this.tokens = new String[] { "AAAAAA00A11D000L", "CSI PIEMONTE", "DEMO 23", "IPA", "20160725152035", "2", "SQGMT++caXxGO/7s3Zu2ow==" };
+
+        this.irideIdentity = new IrideIdentity(this.tokens);
+
+        this.formatter = new IrideIdentityFormatter();
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter.FormatStyle#values()}.
+     */
+    @Test
+    public void testIrideIdentityFormatterHasExpectedFormatStylesCount() {
+        final int expectedFormatStyleCount = 2;
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityFormatterHasExpectedFormatStylesCount");
+        try {
+            final FormatStyle[] result = IrideIdentityFormatter.FormatStyle.values();
+
+            assertThat(result, is(not(nullValue())));
+            assertThat(result, is(arrayWithSize(expectedFormatStyleCount)));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityFormatterHasExpectedFormatStylesCount");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter#format(IrideIdentity, FormatStyle)}.
+     */
+    @Test
+    public void testFormatWithNullIrideIdentityAndNullStyleReturnsNull() {
+        final IrideIdentity                      irideIdentity = null;
+        final IrideIdentityFormatter.FormatStyle formatStyle   = null;
+
+        LOGGER.entering(this.getClass().getName(), "testFormatWithNullIrideIdentityAndNullStyleReturnsNull", new Object[] {irideIdentity, formatStyle});
+        try {
+            final String result = this.formatter.format(irideIdentity, formatStyle);
+
+            assertThat(result, is(nullValue()));
+
+            LOGGER.info("Formatted IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullIrideIdentityAndNullStyleReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter#format(IrideIdentity, FormatStyle)}.
+     */
+    @Test
+    public void testFormatWithNullIrideIdentityReturnsNull() {
+        final IrideIdentity                      irideIdentity = null;
+        final IrideIdentityFormatter.FormatStyle formatStyle   = IrideIdentityFormatter.FormatStyle.INTERNAL_REPRESENTATION;
+
+        LOGGER.entering(this.getClass().getName(), "testFormatWithNullIrideIdentityReturnsNull", new Object[] {irideIdentity, formatStyle});
+        try {
+            final String result = this.formatter.format(irideIdentity, formatStyle);
+
+            assertThat(result, is(nullValue()));
+
+            LOGGER.info("Formatted IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullIrideIdentityReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter#format(IrideIdentity, FormatStyle)}.
+     */
+    @Test
+    public void testFormatWithNullStyleReturnsNull() {
+        final IrideIdentityFormatter.FormatStyle formatStyle = null;
+
+        LOGGER.entering(this.getClass().getName(), "testFormatWithNullStyleReturnsNull", formatStyle);
+        try {
+            final String result = this.formatter.format(this.irideIdentity, formatStyle);
+
+            assertThat(result, is(nullValue()));
+
+            LOGGER.info("Formatted IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullStyleReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityFormatter#format(IrideIdentity, FormatStyle)}.
+     */
+    @Test
+    public void testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation() {
+        final IrideIdentityFormatter.FormatStyle formatStyle = IrideIdentityFormatter.FormatStyle.INTERNAL_REPRESENTATION;
+
+        LOGGER.entering(this.getClass().getName(), "testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation", formatStyle);
+        try {
+            final String result = this.formatter.format(this.irideIdentity, formatStyle);
+
+            assertThat(result, is(not(nullValue())));
+            assertThat(result, is(StringUtils.join(Arrays.copyOfRange(this.tokens, 0, this.tokens.length - 1), IrideIdentityToken.SEPARATOR)));
+
+            LOGGER.info("Formatted IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation");
+        }
+    }
+
+}

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTest.java
@@ -1,0 +1,1284 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.identity;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.geoserver.security.iride.Utils.BLANK;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.geoserver.security.iride.entity.IrideIdentity;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityTokenizationException;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityInvalidTokensException;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityMissingTokenException;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geotools.util.logging.Logging;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.util.SerializationUtils;
+
+/**
+ * <code>IRIDE</code> <code>Digital Identity</code> entity <code>JUnit</code> Test Case.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityTest {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logging.getLogger(IrideIdentityTest.class);
+
+    /**
+     * <code>IRIDE</code> <code>Digital Identity</code> tokens.
+     */
+    private String[] tokens;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        this.tokens = new String[] { "AAAAAA00A11D000L", "CSI PIEMONTE", "DEMO 23", "IPA", "20160725152035", "2", "SQGMT++caXxGO/7s3Zu2ow==" };
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.identity.token.IrideIdentityToken#SEPARATOR}.
+     */
+    @Test
+    public void testIrideIdentityTokenSeparatorIsSlashCharacter() {
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityTokenSeparatorIsSlashCharacter", IrideIdentityToken.SEPARATOR);
+
+        assertThat(IrideIdentityToken.SEPARATOR, is('/'));
+
+        LOGGER.exiting(this.getClass().getName(), "testIrideIdentityTokenSeparatorIsSlashCharacter");
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String[])}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testNewIrideIdentityInstanceWithNullDigitalIdentityTokens() throws IrideIdentityTokenizationException {
+        final String[] tokens = null;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityTokens", tokens);
+        try {
+            new IrideIdentity(tokens);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String[])}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IrideIdentityInvalidTokensException.class)
+    public void testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull() throws IrideIdentityTokenizationException {
+        final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
+        tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = null;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull", tokensWithCodiceFiscaleNull);
+        try {
+            new IrideIdentity(tokensWithCodiceFiscaleNull);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String[])}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IrideIdentityInvalidTokensException.class)
+    public void testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty() throws IrideIdentityTokenizationException {
+        final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
+        tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty", tokensWithCodiceFiscaleNull);
+        try {
+            new IrideIdentity(tokensWithCodiceFiscaleNull);
+        } catch (IrideIdentityInvalidTokensException e) {
+            assertThat(e.getInvalidTokens(), is(not(nullValue())));
+            assertThat(e.getInvalidTokens(), is(not(emptyArray())));
+            assertThat(e.getInvalidTokens(), is(arrayWithSize(1)));
+            assertThat(e.getInvalidTokens()[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String[])}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IrideIdentityInvalidTokensException.class)
+    public void testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank() throws IrideIdentityTokenizationException {
+        final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
+        tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank", tokensWithCodiceFiscaleNull);
+        try {
+            new IrideIdentity(tokensWithCodiceFiscaleNull);
+        } catch (IrideIdentityInvalidTokensException e) {
+            assertThat(e.getInvalidTokens(), is(not(nullValue())));
+            assertThat(e.getInvalidTokens(), is(not(emptyArray())));
+            assertThat(e.getInvalidTokens(), is(arrayWithSize(1)));
+            assertThat(e.getInvalidTokens()[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = NullPointerException.class)
+    public void testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
+        final String value = null;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation", value);
+        try {
+            new IrideIdentity(value);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
+        final String value = BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation", value);
+        try {
+            new IrideIdentity(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
+        final String value = EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation", value);
+        try {
+            new IrideIdentity(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String[])}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testNewIrideIdentityInstanceWithValidDigitalIdentityTokens() throws IrideIdentityTokenizationException {
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityTokens", this.tokens);
+        try {
+            final IrideIdentity result = new IrideIdentity(this.tokens);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getCodFiscale(), is(this.tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result.getNome(), is(this.tokens[IrideIdentityToken.NOME.getPosition()]));
+            assertThat(result.getCognome(), is(this.tokens[IrideIdentityToken.COGNOME.getPosition()]));
+            assertThat(result.getIdProvider(), is(this.tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+            assertThat(result.getTimestamp(), is(this.tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+            assertThat(String.valueOf(result.getLivelloAutenticazione()), is(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+            assertThat(result.getMac(), is(this.tokens[IrideIdentityToken.MAC.getPosition()]));
+            assertThat(result.toString(), is(StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR)));
+            assertThat(result.toInternalRepresentation(), is(tokensToInternalRepresentation()));
+
+            LOGGER.info("IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testNewIrideIdentityInstanceWithValidDigitalIdentityParameters() throws IrideIdentityTokenizationException {
+        final String codFiscale            = this.tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()];
+        final String nome                  = this.tokens[IrideIdentityToken.NOME.getPosition()];
+        final String cognome               = this.tokens[IrideIdentityToken.COGNOME.getPosition()];
+        final String idProvider            = this.tokens[IrideIdentityToken.ID_PROVIDER.getPosition()];
+        final String timestamp             = this.tokens[IrideIdentityToken.TIMESTAMP.getPosition()];
+        final int livelloAutenticazione    = Integer.valueOf(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]);
+        final String mac                   = this.tokens[IrideIdentityToken.MAC.getPosition()];
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityParameters", this.tokens);
+        try {
+            final IrideIdentity result = new IrideIdentity(codFiscale, nome, cognome, idProvider, timestamp, livelloAutenticazione, mac);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getCodFiscale(), is(this.tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result.getNome(), is(this.tokens[IrideIdentityToken.NOME.getPosition()]));
+            assertThat(result.getCognome(), is(this.tokens[IrideIdentityToken.COGNOME.getPosition()]));
+            assertThat(result.getIdProvider(), is(this.tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+            assertThat(result.getTimestamp(), is(this.tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+            assertThat(String.valueOf(result.getLivelloAutenticazione()), is(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+            assertThat(result.getMac(), is(this.tokens[IrideIdentityToken.MAC.getPosition()]));
+            assertThat(result.toString(), is(StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR)));
+            assertThat(result.toInternalRepresentation(), is(tokensToInternalRepresentation()));
+
+            LOGGER.info("IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityParameters");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#IrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation", value);
+        try {
+            final IrideIdentity result = new IrideIdentity(value);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getCodFiscale(), is(this.tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result.getNome(), is(this.tokens[IrideIdentityToken.NOME.getPosition()]));
+            assertThat(result.getCognome(), is(this.tokens[IrideIdentityToken.COGNOME.getPosition()]));
+            assertThat(result.getIdProvider(), is(this.tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+            assertThat(result.getTimestamp(), is(this.tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+            assertThat(String.valueOf(result.getLivelloAutenticazione()), is(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+            assertThat(result.getMac(), is(this.tokens[IrideIdentityToken.MAC.getPosition()]));
+            assertThat(result.toString(), is(value));
+            assertThat(result.toInternalRepresentation(), is(tokensToInternalRepresentation()));
+
+            LOGGER.info("IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#compareTo(IrideIdentity)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceComparesToItself() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceComparesToItself", value);
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            final IrideIdentity irideIdentity2 = irideIdentity1;
+
+            assertThat(irideIdentity1.compareTo(irideIdentity2), is(0));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceComparesToItself");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#compareTo(IrideIdentity)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceComparesToAnother() throws IrideIdentityTokenizationException {
+        final String value1 = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+        final String value2 = "NNRLSN69P26L570X/Aldesino/Innerkofler/IPA/20160531113948/2//VZjBdhZTwU+/7AU0A8HjQ==";
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceComparesToAnother", new String[] { value1, value2 });
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value1);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            final IrideIdentity irideIdentity2 = new IrideIdentity(value2);
+
+            assertThat(irideIdentity2, is(notNullValue()));
+            assertThat(irideIdentity1.compareTo(irideIdentity2), is(lessThan(0)));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceComparesToAnother");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#equals(Object)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceIsEqualToItself() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItself", value);
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            final IrideIdentity irideIdentity2 = irideIdentity1;
+
+            assertThat(irideIdentity1.equals(irideIdentity2), is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItself");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#equals(Object)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceIsNotEqualToNull() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToNull", value);
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            assertThat(irideIdentity1.equals(null), is(false));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#equals(Object)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceIsNotEqualToAnotherClassInstance() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToSubclassInstance", value);
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            final Object anotherClassInstance = new Object();
+
+            assertThat(irideIdentity1.equals(anotherClassInstance), is(false));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToSubclassInstance");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#equals(Object)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testIrideIdentityInstanceIsEqualToItsCopy() throws IrideIdentityTokenizationException {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItsCopy", value);
+        try {
+            final IrideIdentity irideIdentity1 = new IrideIdentity(value);
+
+            assertThat(irideIdentity1, is(notNullValue()));
+
+            final IrideIdentity irideIdentity2 = new IrideIdentity(irideIdentity1.toString());
+
+            assertThat(irideIdentity1.equals(irideIdentity2), is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItsCopy");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#parseIrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testParseIrideIdentityWithNullDigitalRepresentationReturnsNull() {
+        final String value = null;
+
+        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull", value);
+        try {
+            final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
+
+            assertThat(result, is(nullValue()));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#parseIrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull() {
+        final String value = "AAAAAA00011D000L/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull", value);
+        try {
+            final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
+
+            assertThat(result, is(nullValue()));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#parseIrideIdentity(String)}.
+     *
+     * @throws IrideIdentityTokenizationException
+     */
+    @Test
+    public void testParseIrideIdentityWithValidDigitalRepresentation() {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull", value);
+        try {
+            final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
+
+            assertThat(result, is(notNullValue()));
+            assertThat(result.getCodFiscale(), is(this.tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result.getNome(), is(this.tokens[IrideIdentityToken.NOME.getPosition()]));
+            assertThat(result.getCognome(), is(this.tokens[IrideIdentityToken.COGNOME.getPosition()]));
+            assertThat(result.getIdProvider(), is(this.tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+            assertThat(result.getTimestamp(), is(this.tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+            assertThat(String.valueOf(result.getLivelloAutenticazione()), is(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+            assertThat(result.getMac(), is(this.tokens[IrideIdentityToken.MAC.getPosition()]));
+            assertThat(result.toString(), is(value));
+            assertThat(result.toInternalRepresentation(), is(tokensToInternalRepresentation()));
+
+            LOGGER.info("IrideIdentity: " + result);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotInvalidIrideIdentity() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotInvalidIrideIdentity", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(false));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotInvalidIrideIdentity");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithNullValue() {
+        final String value = null;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithBlankValue() {
+        final String value = BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithEmptyValue() {
+        final String value = EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithUnrecognizedValue() {
+        final String value = "UNRECOGNIZED_VALUE";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken() {
+        final String value = "AAAAAA00B77B000F";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingNomeToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingCognomeToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingIdProviderToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingTimestampToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMissingMacToken() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCodiceFiscaleEmpty() {
+        final String value = "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCodiceFiscaleBlank() {
+        final String value = BLANK + "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat() {
+        final String value = "AAAAAA00011D000L/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithNomeEmpty() {
+        final String value = "AAAAAA00B77B000F/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithNomeBlank() {
+        final String value = "AAAAAA00B77B000F/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCognomeEmpty() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + EMPTY + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCognomeBlank() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + BLANK + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithIdProviderEmpty() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + EMPTY + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithIdProviderBlank() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + BLANK + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithTimestampEmpty() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + EMPTY + "/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithTimestampBlank() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + BLANK + "/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithTimestampWithInvalidFormat() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/201605311139/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + EMPTY + "/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + BLANK + "/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/A/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/0/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/3/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMacEmpty() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMacBlank() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithMacOfInvalidLength() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty() {
+        final String value = "AAAAAA00011D000L/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank() {
+        final String value = "AAAAAA00011D000L/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithAllNullTokens() {
+        final String value = null + "/" +
+                             null + "/" +
+                             null + "/" +
+                             null + "/" +
+                             null + "/" +
+                             null + "/" +
+                             null;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithAllEmptyTokens() {
+        final String value = EMPTY + "/" +
+                             EMPTY + "/" +
+                             EMPTY + "/" +
+                             EMPTY + "/" +
+                             EMPTY + "/" +
+                             EMPTY + "/" +
+                             EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isNotValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsNotValidIrideIdentityWithAllBlankTokens() {
+        final String value = BLANK + "/" +
+                             BLANK + "/" +
+                             BLANK + "/" +
+                             BLANK + "/" +
+                             BLANK + "/" +
+                             BLANK + "/" +
+                             BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens", value);
+        try {
+            final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsValidIrideIdentity() {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentity", value);
+        try {
+            final boolean result = IrideIdentity.isValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentity");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsValidIrideIdentityWithComplexMacToken() {
+        final String value = "AAAAAA00A11D000L/CSI PIEMONTE/DEMO 23/IPA/20150223095441/2//VZjBdhZTwU+/7AUMNSHjQ==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken", value);
+        try {
+            final boolean result = IrideIdentity.isValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity#isValidIrideIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testIsValidIrideIdentityWithRealisticDigitalIdentity() {
+        final String value = "NNRLSN69P26L570X/Aldesino/Innerkofler/IPA/20160531113948/2//VZjBdhZTwU+/7AU0A8HjQ==";
+
+        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity", value);
+        try {
+            final boolean result = IrideIdentity.isValidIrideIdentity(value);
+
+            assertThat(result, is(true));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity} serialization.
+     */
+    @Test
+    public void testIrideIdentitySuccesfulSerialization() {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentitySuccesfulSerialization", value);
+        try {
+            final IrideIdentity irideIdentity = IrideIdentity.parseIrideIdentity(value);
+
+            final byte[] serialized = SerializationUtils.serialize(irideIdentity);
+
+            assertThat(serialized, is(not(nullValue())));
+            assertThat(ArrayUtils.toObject(serialized), is(arrayWithSize(greaterThan(0))));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentitySuccesfulSerialization");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.IrideIdentity} serialization.
+     */
+    @Test
+    public void testIrideIdentitySuccesfulDeserialization() {
+        final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
+
+        LOGGER.entering(this.getClass().getName(), "testIrideIdentitySuccesfulDeserialization", value);
+        try {
+            final IrideIdentity irideIdentity1 = IrideIdentity.parseIrideIdentity(value);
+
+            final byte[] serialized = SerializationUtils.serialize(irideIdentity1);
+
+            assertThat(serialized, is(not(nullValue())));
+            assertThat(ArrayUtils.toObject(serialized), is(arrayWithSize(greaterThan(0))));
+
+            final Object deserialized = SerializationUtils.deserialize(serialized);
+
+            assertThat(deserialized, is(not(nullValue())));
+            assertThat(deserialized, is(instanceOf(IrideIdentity.class)));
+
+            final IrideIdentity irideIdentity2 = (IrideIdentity) deserialized;
+
+            assertThat(irideIdentity1, is(not(sameInstance(irideIdentity2))));
+            assertThat(irideIdentity1, is(irideIdentity2));
+            assertThat(irideIdentity1.compareTo(irideIdentity2), is(0));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testIrideIdentitySuccesfulDeserialization");
+        }
+    }
+
+    /**
+     * Helper method to build an {@link IrideIdentity#toInternalRepresentation()} equivalent string joining {@link #tokens}.
+     *
+     * @return an {@link IrideIdentity#toInternalRepresentation()} equivalent string joining {@link #tokens}
+     */
+    private String tokensToInternalRepresentation() {
+        return StringUtils.join(Arrays.copyOfRange(this.tokens, 0, this.tokens.length - 1), IrideIdentityToken.SEPARATOR);
+    }
+
+}

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTokenizerTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTokenizerTest.java
@@ -1,0 +1,337 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.identity;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.geoserver.security.iride.Utils.BLANK;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.logging.Logger;
+
+import org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer;
+import org.geoserver.security.iride.entity.identity.exception.IrideIdentityMissingTokenException;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geotools.util.logging.Logging;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * {@link IrideIdentityTokenizer} <code>JUnit</code> Test Case.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityTokenizerTest {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logging.getLogger(IrideIdentityTokenizerTest.class);
+
+    /**
+     * {@link IrideIdentityTokenizer} instance.
+     */
+    private IrideIdentityTokenizer tokenizer;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        this.tokenizer = new IrideIdentityTokenizer();
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = NullPointerException.class)
+    public void testTokenizationThrowNullPointerExceptionForNullValue() throws IrideIdentityMissingTokenException {
+        final String value = null;
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationThrowNullPointerExceptionForNullValue", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationThrowNullPointerExceptionForNullValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForEmptyValue() throws IrideIdentityMissingTokenException {
+        final String value = EMPTY;
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForEmptyValue", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForEmptyValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForBlankValue() throws IrideIdentityMissingTokenException {
+        final String value = BLANK;
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForBlankValue", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForBlankValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForUnrecognizedValue() throws IrideIdentityMissingTokenException {
+        final String value = "UNRECOGNIZED_VALUE";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForUnrecognizedValue", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForUnrecognizedValue");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingCodiceFiscaleToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingCodiceFiscaleToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingCodiceFiscaleToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingNomeToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingNomeToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.NOME));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingNomeToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingCognomeToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingCognomeToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.COGNOME));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingCognomeToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingIdProviderToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingIdProviderToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.ID_PROVIDER));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingIdProviderToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingTimestampToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingTimestampToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.TIMESTAMP));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingTimestampToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingLivelloAutenticazioneToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingLivelloAutenticazioneToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingLivelloAutenticazioneToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test(expected = IrideIdentityMissingTokenException.class)
+    public void testTokenizationFailForMissingMacToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingMacToken", value);
+        try {
+            this.tokenizer.tokenize(value);
+        } catch (IrideIdentityMissingTokenException e) {
+            assertThat(e.getMissingTokenValue().getToken(), is(IrideIdentityToken.MAC));
+            assertThat(e.getMissingTokenValue().getValue(), is(value));
+
+            throw e;
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingMacToken");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test
+    public void testTokenizationSuccessful() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationSuccessful", value);
+        try {
+            final String[] result = this.tokenizer.tokenize(value);
+
+            assertThat(result, is(arrayWithSize(IrideIdentityToken.values().length)));
+            assertThat(result, is(arrayContaining("AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==")));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationSuccessful");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer#tokenize(java.lang.String)}.
+     *
+     * @throws IrideIdentityMissingTokenException
+     */
+    @Test
+    public void testTokenizationSuccessfulForComplexMacToken() throws IrideIdentityMissingTokenException {
+        final String value = "AAAAAA00A11D000L/CSI PIEMONTE/DEMO 23/IPA/20150223095441/2//VZjBdhZTwU+/7AUMNSHjQ==";
+
+        LOGGER.entering(this.getClass().getName(), "testTokenizationSuccessfulForComplexMacToken", value);
+        try {
+            final String[] result = this.tokenizer.tokenize(value);
+
+            assertThat(result, is(arrayWithSize(IrideIdentityToken.values().length)));
+            assertThat(result, is(arrayContaining("AAAAAA00A11D000L", "CSI PIEMONTE", "DEMO 23", "IPA", "20150223095441", "2", "/VZjBdhZTwU+/7AUMNSHjQ==")));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testTokenizationSuccessfulForComplexMacToken");
+        }
+    }
+
+}

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityValidatorTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityValidatorTest.java
@@ -1,0 +1,887 @@
+/*
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package org.geoserver.security.iride.identity;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+import static org.geoserver.security.iride.Utils.BLANK;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.logging.Logger;
+
+import org.geoserver.security.iride.entity.identity.IrideIdentityValidator;
+import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
+import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
+import org.geoserver.security.iride.entity.util.Utils;
+import org.geotools.util.logging.Logging;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * {@link IrideIdentityValidator} <code>JUnit</code> Test Case.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideIdentityValidatorTest {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = Logging.getLogger(IrideIdentityValidatorTest.class);
+
+    /**
+     * {@link IrideIdentityValidator} instance.
+     */
+    private IrideIdentityValidator validator;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        this.validator = new IrideIdentityValidator();
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateSuccessful() {
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.entering(this.getClass().getName(), "testValidateSuccessful");
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(emptyArray()));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateSuccessful");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateSuccessfulForRealisticDigitalIdentity() {
+        final String[] tokens = new String[] { "NNRLSN69P26L570X", "Aldesino", "Innerkofler", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.entering(this.getClass().getName(), "testValidateSuccessfulForRealisticCodiceFiscale");
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(emptyArray()));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateSuccessfulForRealisticCodiceFiscale");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateFailForInvalidNullTokensArray() {
+        final String[] tokens = null;
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidNullTokensArray");
+        try {
+            this.validator.validate(tokens);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidNullTokensArray");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateFailForInvalidEmptyTokensArray() {
+        final String[] tokens = new String[0];
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidEmptyTokensArray");
+        try {
+            this.validator.validate(tokens);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidEmptyTokensArray");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidateFailForInvalidLengthTokensArray() {
+        final String[] tokens = new String[5];
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidLengthTokensArray");
+        try {
+            this.validator.validate(tokens);
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidLengthTokensArray");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleNull() {
+        final String[] tokens = new String[] { null, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleNull");
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleBlank() {
+        final String[] tokens = new String[] { BLANK, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleBlank");
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleEmpty() {
+        final String[] tokens = new String[] { EMPTY, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleEmpty");
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleWithInvalidFormat() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormat");
+
+        final String[] tokens = new String[] { "AAAAAA00011D000L", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForNomeNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", null, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForNomeBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", BLANK, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForNomeEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", EMPTY, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCognomeNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", null, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCognomeBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", BLANK, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCognomeEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", EMPTY, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForIdProviderNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", null, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForIdProviderBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", BLANK, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForIdProviderEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", EMPTY, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForTimestampNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", null, "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForTimestampBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", BLANK, "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForTimestampEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", EMPTY, "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForTimestampWithInvalidFormat() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampWithInvalidFormat");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "201605311139", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", null, "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", BLANK, "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", EMPTY, "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneWithInvalidFormat() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithInvalidFormat");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "A", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithInvalidFormat");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneWithValue0NotInRange() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue0NotInRange");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "0", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue0NotInRange");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForLivelloAutenticazioneWithValue3NotInRange() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue3NotInRange");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "3", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue3NotInRange");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForMacNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacNull");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", null };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForMacBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", BLANK };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForMacEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", EMPTY };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForMacWithInvalidLenght() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacWithInvalidLenght");
+
+        final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(1));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacWithInvalidLenght");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull");
+
+        final String[] tokens = new String[] { "AAAAAA00011D000L", null, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(2));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank");
+
+        final String[] tokens = new String[] { "AAAAAA00011D000L", BLANK, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(2));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty");
+
+        final String[] tokens = new String[] { "AAAAAA00011D000L", EMPTY, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+            assertThat(result, arrayWithSize(2));
+            assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
+            assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
+            assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForAllNullTokens() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllNullTokens");
+
+        final String[] tokens = new String[] { null, null, null, null, null, null, null };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+
+            final IrideIdentityToken[] irideIdentityTokens = IrideIdentityToken.values();
+
+            assertThat(result, arrayWithSize(irideIdentityTokens.length));
+            for (int i = 0; i < irideIdentityTokens.length; i++) {
+                assertThat(result[i].getToken(), is(irideIdentityTokens[i]));
+                assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
+            }
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllNullTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForAllBlankTokens() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllBlankTokens");
+
+        final String[] tokens = new String[] { BLANK, BLANK, BLANK, BLANK, BLANK, BLANK, BLANK };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+
+            final IrideIdentityToken[] irideIdentityTokens = IrideIdentityToken.values();
+
+            assertThat(result, arrayWithSize(irideIdentityTokens.length));
+            for (int i = 0; i < irideIdentityTokens.length; i++) {
+                assertThat(result[i].getToken(), is(irideIdentityTokens[i]));
+                assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
+            }
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllBlankTokens");
+        }
+    }
+
+    /**
+     * Test method for {@link org.geoserver.security.iride.entity.identity.IrideIdentityValidator.IrideIdentityValidator#validate(java.lang.String)}.
+     */
+    @Test
+    public void testValidateFailForAllEmptyTokens() {
+        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllEmptyTokens");
+
+        final String[] tokens = new String[] { EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY };
+        try {
+            final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
+
+            assertThat(result, is(not(emptyArray())));
+
+            final IrideIdentityToken[] irideIdentityTokens = IrideIdentityToken.values();
+
+            assertThat(result, arrayWithSize(irideIdentityTokens.length));
+            for (int i = 0; i < irideIdentityTokens.length; i++) {
+                assertThat(result[i].getToken(), is(irideIdentityTokens[i]));
+                assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
+            }
+
+            LOGGER.warning(Utils.toString(result));
+        } finally {
+            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllEmptyTokens");
+        }
+    }
+
+}

--- a/security/iride-entities/src/test/resources/.gitignore
+++ b/security/iride-entities/src/test/resources/.gitignore
@@ -1,4 +1,0 @@
-# Hack to commit empty folder: ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/security/iride-entities/src/test/resources/.gitignore
+++ b/security/iride-entities/src/test/resources/.gitignore
@@ -1,0 +1,4 @@
+# Hack to commit empty folder: ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -13,6 +13,7 @@
 
     <!-- sotto moduli del layer di sicurezza -->
     <modules>
+        <module>iride-entities</module>
         <module>sec-iride</module>
     </modules>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -13,7 +13,8 @@
 
     <!-- sotto moduli del layer di sicurezza -->
     <modules>
-        <module>iride-entities</module>
+        <!-- temporary commented -->
+        <!-- module>iride-entities</module -->
         <module>sec-iride</module>
     </modules>
 


### PR DESCRIPTION
#190 

- Added Maven module "iride-entities" for IRIDE entity classes
 - the module is empty at the present moment (nevertheless Maven compiles), sources will be added
