### PR TITLE
Add the configuration files used in the context of sec-iride plugin (issue #215)

### DIFF
--- a/backend/gs_data_dir/security/auth/iride/config.xml
+++ b/backend/gs_data_dir/security/auth/iride/config.xml
@@ -1,0 +1,8 @@
+<irideUsernamePassword>
+  <id>-1706d4a4:141e64cb539:-7ffd</id>
+  <name>iride</name>
+  <className>org.geoserver.security.iride.IrideAuthenticationProvider</className>
+  <serverURL>${iride.service.policy-enforcer-base.url}</serverURL>
+  <applicationName>DECSIRA</applicationName>
+  <userGroupServiceName>iride</userGroupServiceName>
+</irideUsernamePassword>

--- a/backend/gs_data_dir/security/role/iride/config.xml
+++ b/backend/gs_data_dir/security/role/iride/config.xml
@@ -1,0 +1,9 @@
+<irideRoleService>
+  <id>-1706d4a4:141e64cb539:-7ffd</id>
+  <name>iride</name>
+  <className>org.geoserver.security.iride.IrideRoleService</className>
+  <serverURL>${iride.service.policy-enforcer-base.url}</serverURL>
+  <applicationName>DECSIRA</applicationName>
+  <adminRole>SUPUSR_DECSIRA</adminRole>
+  <fallbackRoleService>default</fallbackRoleService>
+</irideRoleService>

--- a/backend/gs_data_dir/security/usergroup/iride/config.xml
+++ b/backend/gs_data_dir/security/usergroup/iride/config.xml
@@ -1,0 +1,7 @@
+<irideUserGroupService>
+  <id>-1706d4a4:141e64cb539:-7ffd</id>
+  <name>iride</name>
+  <className>org.geoserver.security.iride.IrideUserGroupService</className>
+  <serverURL>${iride.service.policy-enforcer-base.url}</serverURL>
+  <applicationName>DECSIRA</applicationName>
+</irideUserGroupService>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -77,4 +77,72 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Copy GeoServer datadir</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/gs_data_dir</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <resources>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>${basedir}/gs_data_dir</directory>
+                                    <includes>
+                                        <include>**/*.xml</include>
+                                    </includes>
+                                    <excludes>
+                                      <exclude>workspaces/**</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                    <id>Zip GeoServer datadir</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                        <configuration>
+                            <tasks>
+                                <zip destfile="${basedir}/target/gs_data_dir.zip">
+                                    <zipfileset dir="${basedir}/target/gs_data_dir" includes="**/**" />
+                                </zip>
+                                <delete dir="${basedir}/target/gs_data_dir" failonerror="false" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>produzione</id>
+            <properties>
+                <iride.service.policy-enforcer-base.url>http://applogic-nmsf2e.csi.it/pep_wsfad_nmsf_policy/services/PolicyEnforcerBase</iride.service.policy-enforcer-base.url>
+            </properties>
+        </profile>
+        <profile>
+            <id>demo</id>
+            <properties>
+                <iride.service.policy-enforcer-base.url>http://tst-applogic-nmsf2e.csi.it/pep_wsfad_nmsf_policy/services/PolicyEnforcerBase</iride.service.policy-enforcer-base.url>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
#215 
- added configuration files for each security service involved in `sec-iride` plugin security services
- modified `Maven` `POM` to add build profiles, one for each execution environments:
  - `demo`
  - `produzione`
 - to properly compile each configuration file as per execution environments
- everything packed in a convenient zip archive, simply named `gs_data_dir.zip`
