### PR TITLE
IRIDE modules cleanup

### DIFF
--- a/security/iride-commons/pom.xml
+++ b/security/iride-commons/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>IRIDE commons classes</name>
+    <name>CSI SIRA - IRIDE commons classes</name>
     <description>Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.</description>
 
     <url>https://github.com/geosolutions-it/csi-sira/tree/master/security/iride-commons</url>

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/AbstractFactory.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/AbstractFactory.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/Factory.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/Factory.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/validator/UrlValidatorFactory.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/validator/UrlValidatorFactory.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/logging/LoggerProvider.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/logging/LoggerProvider.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/object/ObjectRegistry.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/object/ObjectRegistry.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/object/RegistrableObject.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/object/RegistrableObject.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/template/TemplateEngine.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/template/TemplateEngine.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/template/TemplateEngineException.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/template/TemplateEngineException.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/ErrorHandlerUtils.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/ErrorHandlerUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/StringResult.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/StringResult.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformer.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformer.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerErrorHandler.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerUtils.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerUtils.java
@@ -1,5 +1,5 @@
 /*
- *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Classes common to the modules offering authentication and authorization functionalities using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/pom.xml
+++ b/security/iride-entities/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>IRIDE entity classes</name>
+    <name>CSI SIRA - IRIDE entity classes</name>
     <description>Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.</description>
 
     <url>https://github.com/geosolutions-it/csi-sira/tree/master/security/iride-entities</url>

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideApplication.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideApplication.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideInfoPersona.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideInfoPersona.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideRole.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideRole.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideUseCase.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideUseCase.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityFormatter.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityFormatter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/token/value/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/package-info.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Entity classes involved during authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/pom.xml
+++ b/security/iride-service-client/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>IRIDE service client</name>
+    <name>CSI SIRA - IRIDE service client</name>
     <description>Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.</description>
 
     <url>https://github.com/geosolutions-it/csi-sira/tree/master/security/iride-service-client</url>

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverter.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverter.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverter.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideRoleConverter.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideRoleConverter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverter.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverter.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/package-info.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/entity/converter/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/http/HttpClientFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/http/HttpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/http/HttpClientFactoryBean.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/http/HttpClientFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerConfigurationFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerConfigurationFactoryBean.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerConfigurationFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerTemplateEngineFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/template/freemarker/FreeMarkerTemplateEngineFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactoryBean.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/AbstractXmlUnitTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/AbstractXmlUnitTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/JaxpImplementationInfoPoint.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/JaxpImplementationInfoPoint.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/AbstractXStreamTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/AbstractXStreamTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideRoleConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideRoleConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverterTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/request/IridePolicyRequestHandlerTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/request/IridePolicyRequestHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/response/IridePolicyResponseHandlerTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/response/IridePolicyResponseHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/AbstractIrideSoapRequestTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/AbstractIrideSoapRequestTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindRuoliForPersonaInApplicationTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindRuoliForPersonaInApplicationTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindRuoliForPersonaInUseCaseTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindRuoliForPersonaInUseCaseTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindUseCasesForPersonaInApplicationTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/FindUseCasesForPersonaInApplicationTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/GetInfoPersonaInUseCaseTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/GetInfoPersonaInUseCaseTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IdentificaUserPasswordTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IdentificaUserPasswordTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsIdentitaAutenticaTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsIdentitaAutenticaTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsPersonaAutorizzataInUseCaseTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsPersonaAutorizzataInUseCaseTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsPersonaInRuoloTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/IsPersonaInRuoloTemplateCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerConfigurationDefaultFactoryTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerConfigurationDefaultFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerTemplateEngineFactoryTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerTemplateEngineFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/AbstractTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/AbstractTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindRuoliForPersonaInApplicationTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindRuoliForPersonaInApplicationTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindRuoliForPersonaInUseCaseTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindRuoliForPersonaInUseCaseTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindUseCasesForPersonaInApplicationTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/FindUseCasesForPersonaInApplicationTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/GetInfoPersonaInUseCaseTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/GetInfoPersonaInUseCaseTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IdentificaUserPasswordTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IdentificaUserPasswordTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsIdentitaAutenticaTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsIdentitaAutenticaTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsPersonaAutorizzataInUseCaseTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsPersonaAutorizzataInUseCaseTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsPersonaInRuoloTemplateEngineTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/template/IsPersonaInRuoloTemplateEngineTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/AbstractXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/AbstractXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/AbstractOthersXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/AbstractOthersXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/AbstractIridePolicyResponseXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/AbstractIridePolicyResponseXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/IridePolicyResponseXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/IridePolicyResponseXslProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/http/HttpClientFactory.java
+++ b/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/http/HttpClientFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/http/HttpClientFactoryBean.java
+++ b/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/http/HttpClientFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/sax/SAXSourceFactoryBean.java
+++ b/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/sax/SAXSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/util/UrlValidatorFactory.java
+++ b/security/iride-service-client/src/test/java/test/org/geoserver/security/iride/util/factory/util/UrlValidatorFactory.java
@@ -1,5 +1,5 @@
 /*
- *  GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+ *  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
  *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/security/sec-iride/pom.xml
+++ b/security/sec-iride/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>CSI-Piemonte IRIDE / GeoServer Security Provider plugin</name>
+    <name>CSI SIRA - IRIDE / GeoServer Security Provider</name>
     <description>GeoServer Security Provider plugin with which doing authentication and authorization operations using CSI-Piemonte IRIDE Service.</description>
 
     <url>https://github.com/geosolutions-it/csi-sira/tree/master/security/sec-iride</url>


### PR DESCRIPTION
#249 

- cleanup of source codes license headers
- cleanup of `Maven` modules names
