### PR TITLE
IRIDE modules logging mechanism review (issue #254)

### DIFF
--- a/security/iride-commons/pom.xml
+++ b/security/iride-commons/pom.xml
@@ -77,6 +77,7 @@
         <!-- Dependencies -->
         <spring.version>3.1.4.RELEASE</spring.version>
         <spring-security.version>3.1.0.RELEASE</spring-security.version>
+        <slf4j.version>1.6.4</slf4j.version>
 
         <!-- Testing -->
         <test.exclude.pattern>none</test.exclude.pattern>
@@ -159,12 +160,17 @@
             <version>17.0</version>
         </dependency>
 
-		<!-- org.geotools/gt-metadata -->
-		<dependency>
-		    <groupId>org.geotools</groupId>
-		    <artifactId>gt-metadata</artifactId>
-		    <version>14.0</version>
-		</dependency>
+        <!-- LOGGING -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
         <!-- Test Dependencies (see https://tedvinke.wordpress.com/2013/12/17/mixing-junit-hamcrest-and-mockito-explaining-nosuchmethoderror/) -->
 
@@ -292,7 +298,7 @@
                     <testFailureIgnore>${test.allow.failure.ignore}</testFailureIgnore>
                     <systemProperties>
                         <property>
-                            <name>java.util.logging.config.file</name>
+                            <name>log4j.configuration</name>
                             <value>src/test/resources/conf/logging.properties</value>
                         </property>
                     </systemProperties>

--- a/security/iride-commons/pom.xml
+++ b/security/iride-commons/pom.xml
@@ -299,7 +299,7 @@
                     <systemProperties>
                         <property>
                             <name>log4j.configuration</name>
-                            <value>src/test/resources/conf/logging.properties</value>
+                            <value>conf/logging.properties</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/AbstractFactory.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/factory/AbstractFactory.java
@@ -18,9 +18,8 @@
  */
 package org.geoserver.security.iride.util.factory;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 /**
  * Base <em>Factory</em> class.

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/logging/LoggerProvider.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/logging/LoggerProvider.java
@@ -18,9 +18,8 @@
  */
 package org.geoserver.security.iride.util.logging;
 
-import java.util.logging.Logger;
-
-import org.geotools.util.logging.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Provider for various application "layers" {@link Logger}s.
@@ -33,25 +32,25 @@ public enum LoggerProvider {
      * {@link Logger} used by all <code>IRIDE</code> entities (and related) objects.
      */
     ENTITY(
-    	Logging.getLogger(Constants.LOGGER_BASE_NAME + ".entity")
+    	LoggerFactory.getLogger(Constants.LOGGER_BASE_NAME + ".entity")
     ),
     /**
      * {@link Logger} used by all <a href="http://docs.geoserver.org/latest/en/developer/programming-guide/security/index.html#security-services">Security Services</a>.
      */
     SECURITY(
-    	Logging.getLogger(Constants.LOGGER_BASE_NAME + ".security")
+    	LoggerFactory.getLogger(Constants.LOGGER_BASE_NAME + ".security")
     ),
     /**
      * {@link Logger} used by <code>IRIDE</code> "policies" enforcer interfaces instances.
      */
     POLICY(
-    	Logging.getLogger(Constants.LOGGER_BASE_NAME + ".policy")
+    	LoggerFactory.getLogger(Constants.LOGGER_BASE_NAME + ".policy")
     ),
     /**
      * {@link Logger} used by utility and/or helper classes.
      */
     UTIL(
-    	Logging.getLogger(Constants.LOGGER_BASE_NAME + ".util")
+    	LoggerFactory.getLogger(Constants.LOGGER_BASE_NAME + ".util")
     ),
     ;
 
@@ -82,7 +81,7 @@ public enum LoggerProvider {
         final int separator = name.lastIndexOf('.');
         name = (separator >= 1) ? name.substring(0, separator) : "";
 
-        return Logger.getLogger(name);
+        return LoggerFactory.getLogger(name);
     }
 
     /**
@@ -99,12 +98,12 @@ public enum LoggerProvider {
      *
      * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
      */
-    private static final class Constants {
+    public static final class Constants {
 
         /**
          * {@link Logger} base name.
          */
-        static final String LOGGER_BASE_NAME = "org.geoserver.security.iride";
+        public static final String LOGGER_BASE_NAME = "org.geoserver.security.iride";
 
         /**
          * Constructor.

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformer.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformer.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
@@ -36,6 +35,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
 
@@ -183,7 +183,7 @@ public final class XmlTransformer {
 
             return transformer;
         } catch (TransformerConfigurationException e) {
-            LOGGER.severe(ErrorHandlerUtils.getErrorMessage(e));
+            LOGGER.error(ErrorHandlerUtils.getErrorMessage(e));
 
             throw e;
         }

--- a/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerErrorHandler.java
+++ b/security/iride-commons/src/main/java/org/geoserver/security/iride/util/xml/transform/XmlTransformerErrorHandler.java
@@ -18,12 +18,11 @@
  */
 package org.geoserver.security.iride.util.xml.transform;
 
-import java.util.logging.Logger;
-
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.TransformerException;
 
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -48,7 +47,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void warning(SAXParseException exception) throws SAXException {
-        LOGGER.fine(exception.toString());
+        LOGGER.trace(exception.toString());
     }
 
     /* (non-Javadoc)
@@ -56,7 +55,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void warning(TransformerException exception) throws TransformerException {
-        LOGGER.fine(ErrorHandlerUtils.getErrorMessage(exception));
+        LOGGER.trace(ErrorHandlerUtils.getErrorMessage(exception));
     }
 
     /*
@@ -65,7 +64,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void error(SAXParseException exception) throws SAXException {
-        LOGGER.warning(exception.toString());
+        LOGGER.warn(exception.toString());
     }
 
     /* (non-Javadoc)
@@ -73,7 +72,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void error(TransformerException exception) throws TransformerException {
-        LOGGER.warning(ErrorHandlerUtils.getErrorMessage(exception));
+        LOGGER.warn(ErrorHandlerUtils.getErrorMessage(exception));
     }
 
     /*
@@ -82,7 +81,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void fatalError(SAXParseException exception) throws SAXException {
-        LOGGER.severe(exception.toString());
+        LOGGER.error(exception.toString());
 
         throw exception;
     }
@@ -92,7 +91,7 @@ public final class XmlTransformerErrorHandler implements ErrorHandler, ErrorList
      */
     @Override
     public void fatalError(TransformerException exception) throws TransformerException {
-        LOGGER.severe(ErrorHandlerUtils.getErrorMessage(exception));
+        LOGGER.error(ErrorHandlerUtils.getErrorMessage(exception));
 
         throw exception;
     }

--- a/security/iride-entities/pom.xml
+++ b/security/iride-entities/pom.xml
@@ -287,7 +287,7 @@
                     <testFailureIgnore>${test.allow.failure.ignore}</testFailureIgnore>
                     <systemProperties>
                         <property>
-                            <name>java.util.logging.config.file</name>
+                            <name>log4j.configuration</name>
                             <value>src/test/resources/conf/logging.properties</value>
                         </property>
                     </systemProperties>

--- a/security/iride-entities/pom.xml
+++ b/security/iride-entities/pom.xml
@@ -288,7 +288,7 @@
                     <systemProperties>
                         <property>
                             <name>log4j.configuration</name>
-                            <value>src/test/resources/conf/logging.properties</value>
+                            <value>conf/logging.properties</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideIdentity.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/IrideIdentity.java
@@ -20,7 +20,6 @@ package org.geoserver.security.iride.entity;
 
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -38,6 +37,7 @@ import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
 import org.geoserver.security.iride.entity.util.Utils;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 /**
  * <code>IRIDE</code> <code>Digital Identity</code> entity.
@@ -199,7 +199,7 @@ public final class IrideIdentity implements Comparable<IrideIdentity>, Serializa
         try {
             irideIdentity = new IrideIdentity(StringUtils.defaultString(irideDigitalIdentity));
         } catch (IrideIdentityTokenizationException e) {
-            LOGGER.fine("IRIDE Identity tokenization error: " + e.getMessage());
+            LOGGER.trace("IRIDE Identity tokenization error: {}", e.getMessage());
         }
 
         return irideIdentity;
@@ -227,12 +227,12 @@ public final class IrideIdentity implements Comparable<IrideIdentity>, Serializa
             if (ArrayUtils.isEmpty(invalidTokens)) {
                 return true;
             } else {
-                LOGGER.fine(Utils.toString(invalidTokens));
+                LOGGER.trace(Utils.toString(invalidTokens));
 
                 return false;
             }
         } catch (IrideIdentityTokenizationException e) {
-            LOGGER.fine("IRIDE Identity tokenization error: " + e.getMessage());
+            LOGGER.trace("IRIDE Identity tokenization error: {}", e.getMessage());
 
             return false;
         }

--- a/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityValidator.java
+++ b/security/iride-entities/src/main/java/org/geoserver/security/iride/entity/identity/IrideIdentityValidator.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -35,6 +34,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 /**
  * <code>IRIDE</code> <code>Digital Identity</code> validator.
@@ -90,7 +90,7 @@ public final class IrideIdentityValidator {
      * @return {@code true} <em>if and only if all tokens are valid</em>, {@code false} otherwise
      */
     public IrideIdentityInvalidTokenValue[] validate(String... tokens) {
-        LOGGER.finer("IRIDE Identity tokens: " + Arrays.toString(tokens));
+        LOGGER.trace("IRIDE Identity tokens: {}", Arrays.toString(tokens));
 
         this.checkTokens(tokens);
 
@@ -278,7 +278,7 @@ public final class IrideIdentityValidator {
 
             return true;
         } catch (ParseException e) {
-            LOGGER.fine("Invalid date format: " + e.getMessage());
+            LOGGER.trace("Invalid date format: {}", e.getMessage());
 
             return false;
         }
@@ -309,7 +309,7 @@ public final class IrideIdentityValidator {
 
             return true;
         } catch (NumberFormatException e) {
-            LOGGER.fine("Invalid number format: " + e.getMessage());
+            LOGGER.trace("Invalid number format: {}", e.getMessage());
 
             return false;
         }

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityFormatterTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.security.iride.entity.IrideIdentity;
@@ -32,6 +31,7 @@ import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 /**
  * <code>IRIDE</code> <code>Digital Identity</code> entity formatter <code>JUnit</code> Test Case.
@@ -79,14 +79,14 @@ public final class IrideIdentityFormatterTest {
     public void testIrideIdentityFormatterHasExpectedFormatStylesCount() {
         final int expectedFormatStyleCount = 2;
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityFormatterHasExpectedFormatStylesCount");
+        LOGGER.trace("BEGIN {}::testIrideIdentityFormatterHasExpectedFormatStylesCount - {}", this.getClass().getName());
         try {
             final FormatStyle[] result = IrideIdentityFormatter.FormatStyle.values();
 
             assertThat(result, is(not(nullValue())));
             assertThat(result, is(arrayWithSize(expectedFormatStyleCount)));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityFormatterHasExpectedFormatStylesCount");
+        	LOGGER.trace("END {}::testIrideIdentityFormatterHasExpectedFormatStylesCount", this.getClass().getName());
         }
     }
 
@@ -98,7 +98,7 @@ public final class IrideIdentityFormatterTest {
         final IrideIdentity                      irideIdentity = null;
         final IrideIdentityFormatter.FormatStyle formatStyle   = null;
 
-        LOGGER.entering(this.getClass().getName(), "testFormatWithNullIrideIdentityAndNullStyleReturnsNull", new Object[] {irideIdentity, formatStyle});
+        LOGGER.trace("BEGIN {}::testFormatWithNullIrideIdentityAndNullStyleReturnsNull - {}, {}", new Object[] {this.getClass().getName(), irideIdentity, formatStyle});
         try {
             final String result = this.formatter.format(irideIdentity, formatStyle);
 
@@ -106,7 +106,7 @@ public final class IrideIdentityFormatterTest {
 
             LOGGER.info("Formatted IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullIrideIdentityAndNullStyleReturnsNull");
+        	LOGGER.trace("END {}::testFormatWithNullIrideIdentityAndNullStyleReturnsNull", this.getClass().getName());
         }
     }
 
@@ -118,7 +118,7 @@ public final class IrideIdentityFormatterTest {
         final IrideIdentity                      irideIdentity = null;
         final IrideIdentityFormatter.FormatStyle formatStyle   = IrideIdentityFormatter.FormatStyle.INTERNAL_REPRESENTATION;
 
-        LOGGER.entering(this.getClass().getName(), "testFormatWithNullIrideIdentityReturnsNull", new Object[] {irideIdentity, formatStyle});
+        LOGGER.trace("BEGIN {}::testFormatWithNullIrideIdentityReturnsNull - {}, {}", new Object[] {this.getClass().getName(), irideIdentity, formatStyle});
         try {
             final String result = this.formatter.format(irideIdentity, formatStyle);
 
@@ -126,7 +126,7 @@ public final class IrideIdentityFormatterTest {
 
             LOGGER.info("Formatted IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullIrideIdentityReturnsNull");
+        	LOGGER.trace("END {}::testFormatWithNullIrideIdentityAndNullStyleReturnsNull", this.getClass().getName());
         }
     }
 
@@ -137,7 +137,7 @@ public final class IrideIdentityFormatterTest {
     public void testFormatWithNullStyleReturnsNull() {
         final IrideIdentityFormatter.FormatStyle formatStyle = null;
 
-        LOGGER.entering(this.getClass().getName(), "testFormatWithNullStyleReturnsNull", formatStyle);
+        LOGGER.trace("BEGIN {}::testFormatWithNullStyleReturnsNull - {}, {}", new Object[] {this.getClass().getName(), irideIdentity, formatStyle});
         try {
             final String result = this.formatter.format(this.irideIdentity, formatStyle);
 
@@ -145,7 +145,7 @@ public final class IrideIdentityFormatterTest {
 
             LOGGER.info("Formatted IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testFormatWithNullStyleReturnsNull");
+        	LOGGER.trace("END {}::testFormatWithNullStyleReturnsNull", this.getClass().getName());
         }
     }
 
@@ -156,7 +156,7 @@ public final class IrideIdentityFormatterTest {
     public void testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation() {
         final IrideIdentityFormatter.FormatStyle formatStyle = IrideIdentityFormatter.FormatStyle.INTERNAL_REPRESENTATION;
 
-        LOGGER.entering(this.getClass().getName(), "testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation", formatStyle);
+        LOGGER.trace("BEGIN {}::testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation - {}, {}", new Object[] {this.getClass().getName(), irideIdentity, formatStyle});
         try {
             final String result = this.formatter.format(this.irideIdentity, formatStyle);
 
@@ -165,7 +165,7 @@ public final class IrideIdentityFormatterTest {
 
             LOGGER.info("Formatted IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation");
+        	LOGGER.trace("END {}::testFormatWithInternalRepresentationStyleReturnsValidDigitalRepresentation", this.getClass().getName());
         }
     }
 

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
@@ -36,6 +35,7 @@ import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 import org.springframework.util.SerializationUtils;
 
 /**
@@ -68,11 +68,11 @@ public final class IrideIdentityTest {
      */
     @Test
     public void testIrideIdentityTokenSeparatorIsSlashCharacter() {
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityTokenSeparatorIsSlashCharacter", IrideIdentityToken.SEPARATOR);
+        LOGGER.trace("BEGIN {}::testIrideIdentityTokenSeparatorIsSlashCharacter - {}", this.getClass().getName(), IrideIdentityToken.SEPARATOR);
 
         assertThat(IrideIdentityToken.SEPARATOR, is('/'));
 
-        LOGGER.exiting(this.getClass().getName(), "testIrideIdentityTokenSeparatorIsSlashCharacter");
+        LOGGER.trace("END {}::testIrideIdentityTokenSeparatorIsSlashCharacter", this.getClass().getName());
     }
 
     /**
@@ -84,11 +84,11 @@ public final class IrideIdentityTest {
     public void testNewIrideIdentityInstanceWithNullDigitalIdentityTokens() throws IrideIdentityTokenizationException {
         final String[] tokens = null;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityTokens", tokens);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithNullDigitalIdentityTokens - {}", this.getClass().getName(), tokens);
         try {
             new IrideIdentity(tokens);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityTokens");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithNullDigitalIdentityTokens", this.getClass().getName());
         }
     }
 
@@ -102,11 +102,11 @@ public final class IrideIdentityTest {
         final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
         tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = null;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull", tokensWithCodiceFiscaleNull);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull - {}", this.getClass().getName(), tokensWithCodiceFiscaleNull);
         try {
             new IrideIdentity(tokensWithCodiceFiscaleNull);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleNull", this.getClass().getName());
         }
     }
 
@@ -117,22 +117,22 @@ public final class IrideIdentityTest {
      */
     @Test(expected = IrideIdentityInvalidTokensException.class)
     public void testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty() throws IrideIdentityTokenizationException {
-        final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
-        tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = EMPTY;
+        final String[] tokensWithCodiceFiscaleEmpty = Arrays.copyOf(this.tokens, this.tokens.length);
+        tokensWithCodiceFiscaleEmpty[IrideIdentityToken.CODICE_FISCALE.getPosition()] = EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty", tokensWithCodiceFiscaleNull);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty - {}", this.getClass().getName(), tokensWithCodiceFiscaleEmpty);
         try {
-            new IrideIdentity(tokensWithCodiceFiscaleNull);
+            new IrideIdentity(tokensWithCodiceFiscaleEmpty);
         } catch (IrideIdentityInvalidTokensException e) {
             assertThat(e.getInvalidTokens(), is(not(nullValue())));
             assertThat(e.getInvalidTokens(), is(not(emptyArray())));
             assertThat(e.getInvalidTokens(), is(arrayWithSize(1)));
             assertThat(e.getInvalidTokens()[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
-            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleEmpty[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleEmpty", this.getClass().getName());
         }
     }
 
@@ -143,22 +143,22 @@ public final class IrideIdentityTest {
      */
     @Test(expected = IrideIdentityInvalidTokensException.class)
     public void testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank() throws IrideIdentityTokenizationException {
-        final String[] tokensWithCodiceFiscaleNull = Arrays.copyOf(this.tokens, this.tokens.length);
-        tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()] = BLANK;
+        final String[] tokensWithCodiceFiscaleBlank = Arrays.copyOf(this.tokens, this.tokens.length);
+        tokensWithCodiceFiscaleBlank[IrideIdentityToken.CODICE_FISCALE.getPosition()] = BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank", tokensWithCodiceFiscaleNull);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank - {}", this.getClass().getName(), tokensWithCodiceFiscaleBlank);
         try {
-            new IrideIdentity(tokensWithCodiceFiscaleNull);
+            new IrideIdentity(tokensWithCodiceFiscaleBlank);
         } catch (IrideIdentityInvalidTokensException e) {
             assertThat(e.getInvalidTokens(), is(not(nullValue())));
             assertThat(e.getInvalidTokens(), is(not(emptyArray())));
             assertThat(e.getInvalidTokens(), is(arrayWithSize(1)));
             assertThat(e.getInvalidTokens()[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
-            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleNull[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
+            assertThat(e.getInvalidTokens()[0].getValue(), is(tokensWithCodiceFiscaleBlank[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithDigitalIdentityTokensWithCodiceFiscaleBlank", this.getClass().getName());
         }
     }
 
@@ -171,11 +171,11 @@ public final class IrideIdentityTest {
     public void testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
         final String value = null;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation", value);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation - {}", this.getClass().getName(), value);
         try {
             new IrideIdentity(value);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithNullDigitalIdentityStringRepresentation", this.getClass().getName());
         }
     }
 
@@ -188,7 +188,7 @@ public final class IrideIdentityTest {
     public void testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
         final String value = BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation", value);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation - {}", this.getClass().getName(), value);
         try {
             new IrideIdentity(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -197,7 +197,7 @@ public final class IrideIdentityTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithBlankDigitalIdentityStringRepresentation", this.getClass().getName());
         }
     }
 
@@ -210,7 +210,7 @@ public final class IrideIdentityTest {
     public void testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
         final String value = EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation", value);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation - {}", this.getClass().getName(), value);
         try {
             new IrideIdentity(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -219,7 +219,7 @@ public final class IrideIdentityTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithEmptyDigitalIdentityStringRepresentation", this.getClass().getName());
         }
     }
 
@@ -230,7 +230,7 @@ public final class IrideIdentityTest {
      */
     @Test
     public void testNewIrideIdentityInstanceWithValidDigitalIdentityTokens() throws IrideIdentityTokenizationException {
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityTokens", this.tokens);
+    	LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithValidDigitalIdentityTokens - {}", this.getClass().getName(), this.tokens);
         try {
             final IrideIdentity result = new IrideIdentity(this.tokens);
 
@@ -247,7 +247,7 @@ public final class IrideIdentityTest {
 
             LOGGER.info("IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityTokens");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithValidDigitalIdentityTokens", this.getClass().getName());
         }
     }
 
@@ -266,7 +266,7 @@ public final class IrideIdentityTest {
         final int livelloAutenticazione    = Integer.valueOf(this.tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]);
         final String mac                   = this.tokens[IrideIdentityToken.MAC.getPosition()];
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityParameters", this.tokens);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithValidDigitalIdentityParameters - {}", this.getClass().getName(), this.tokens);
         try {
             final IrideIdentity result = new IrideIdentity(codFiscale, nome, cognome, idProvider, timestamp, livelloAutenticazione, mac);
 
@@ -283,7 +283,7 @@ public final class IrideIdentityTest {
 
             LOGGER.info("IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityParameters");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithValidDigitalIdentityParameters", this.getClass().getName());
         }
     }
 
@@ -296,7 +296,7 @@ public final class IrideIdentityTest {
     public void testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation", value);
+        LOGGER.trace("BEGIN {}::testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation - {}", this.getClass().getName(), this.tokens);
         try {
             final IrideIdentity result = new IrideIdentity(value);
 
@@ -313,7 +313,7 @@ public final class IrideIdentityTest {
 
             LOGGER.info("IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation");
+        	LOGGER.trace("END {}::testNewIrideIdentityInstanceWithValidDigitalIdentityStringRepresentation", this.getClass().getName());
         }
     }
 
@@ -326,7 +326,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentityInstanceComparesToItself() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceComparesToItself", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceComparesToItself - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value);
 
@@ -336,7 +336,7 @@ public final class IrideIdentityTest {
 
             assertThat(irideIdentity1.compareTo(irideIdentity2), is(0));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceComparesToItself");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceComparesToItself", this.getClass().getName());
         }
     }
 
@@ -350,7 +350,7 @@ public final class IrideIdentityTest {
         final String value1 = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
         final String value2 = "NNRLSN69P26L570X/Aldesino/Innerkofler/IPA/20160531113948/2//VZjBdhZTwU+/7AU0A8HjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceComparesToAnother", new String[] { value1, value2 });
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceComparesToAnother - {}", new String[] { this.getClass().getName(), value1, value2 });
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value1);
 
@@ -361,7 +361,7 @@ public final class IrideIdentityTest {
             assertThat(irideIdentity2, is(notNullValue()));
             assertThat(irideIdentity1.compareTo(irideIdentity2), is(lessThan(0)));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceComparesToAnother");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceComparesToAnother", this.getClass().getName());
         }
     }
 
@@ -374,7 +374,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentityInstanceIsEqualToItself() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItself", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceIsEqualToItself - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value);
 
@@ -384,7 +384,7 @@ public final class IrideIdentityTest {
 
             assertThat(irideIdentity1.equals(irideIdentity2), is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItself");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceIsEqualToItself", this.getClass().getName());
         }
     }
 
@@ -397,7 +397,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentityInstanceIsNotEqualToNull() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToNull", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceIsNotEqualToNull - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value);
 
@@ -405,7 +405,7 @@ public final class IrideIdentityTest {
 
             assertThat(irideIdentity1.equals(null), is(false));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToNull");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceIsNotEqualToNull", this.getClass().getName());
         }
     }
 
@@ -418,7 +418,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentityInstanceIsNotEqualToAnotherClassInstance() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToSubclassInstance", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceIsNotEqualToSubclassInstance - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value);
 
@@ -428,7 +428,7 @@ public final class IrideIdentityTest {
 
             assertThat(irideIdentity1.equals(anotherClassInstance), is(false));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsNotEqualToSubclassInstance");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceIsNotEqualToSubclassInstance", this.getClass().getName());
         }
     }
 
@@ -441,7 +441,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentityInstanceIsEqualToItsCopy() throws IrideIdentityTokenizationException {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItsCopy", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentityInstanceIsEqualToItsCopy - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = new IrideIdentity(value);
 
@@ -451,7 +451,7 @@ public final class IrideIdentityTest {
 
             assertThat(irideIdentity1.equals(irideIdentity2), is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentityInstanceIsEqualToItsCopy");
+        	LOGGER.trace("END {}::testIrideIdentityInstanceIsEqualToItsCopy", this.getClass().getName());
         }
     }
 
@@ -464,13 +464,13 @@ public final class IrideIdentityTest {
     public void testParseIrideIdentityWithNullDigitalRepresentationReturnsNull() {
         final String value = null;
 
-        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull", value);
+        LOGGER.trace("BEGIN {}::testParseIrideIdentityWithNullDigitalRepresentationReturnsNull - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
 
             assertThat(result, is(nullValue()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull");
+            LOGGER.trace("END {}::testParseIrideIdentityWithNullDigitalRepresentationReturnsNull", this.getClass().getName());
         }
     }
 
@@ -483,13 +483,13 @@ public final class IrideIdentityTest {
     public void testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull() {
         final String value = "AAAAAA00011D000L/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull", value);
+        LOGGER.trace("BEGIN {}::testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
 
             assertThat(result, is(nullValue()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull");
+        	LOGGER.trace("END {}::testParseIrideIdentityWithNotValidDigitalRepresentationReturnsNull", this.getClass().getName());
         }
     }
 
@@ -502,7 +502,7 @@ public final class IrideIdentityTest {
     public void testParseIrideIdentityWithValidDigitalRepresentation() {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull", value);
+        LOGGER.trace("BEGIN {}::testParseIrideIdentityWithValidDigitalRepresentation - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity result = IrideIdentity.parseIrideIdentity(value);
 
@@ -519,7 +519,7 @@ public final class IrideIdentityTest {
 
             LOGGER.info("IrideIdentity: " + result);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testParseIrideIdentityWithNullDigitalRepresentationReturnsNull");
+        	LOGGER.trace("END {}::testParseIrideIdentityWithValidDigitalRepresentation", this.getClass().getName());
         }
     }
 
@@ -530,13 +530,13 @@ public final class IrideIdentityTest {
     public void testIsNotInvalidIrideIdentity() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotInvalidIrideIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsNotInvalidIrideIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(false));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotInvalidIrideIdentity");
+        	LOGGER.trace("END {}::testIsNotInvalidIrideIdentity", this.getClass().getName());
         }
     }
 
@@ -547,13 +547,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithNullValue() {
         final String value = null;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNullValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNullValue", this.getClass().getName());
         }
     }
 
@@ -564,13 +564,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithBlankValue() {
         final String value = BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithBlankValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue");
+            LOGGER.trace("END {}::testIsNotValidIrideIdentityWithBlankValue", this.getClass().getName());
         }
     }
 
@@ -581,13 +581,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithEmptyValue() {
         final String value = EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithEmptyValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithEmptyValue", this.getClass().getName());
         }
     }
 
@@ -598,13 +598,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithUnrecognizedValue() {
         final String value = "UNRECOGNIZED_VALUE";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithUnrecognizedValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithUnrecognizedValue", this.getClass().getName());
         }
     }
 
@@ -615,13 +615,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken() {
         final String value = "AAAAAA00B77B000F";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken", this.getClass().getName());
         }
     }
 
@@ -632,13 +632,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingNomeToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingNomeToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingNomeToken", this.getClass().getName());
         }
     }
 
@@ -649,13 +649,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingCognomeToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingCognomeToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingCognomeToken", this.getClass().getName());
         }
     }
 
@@ -666,13 +666,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingIdProviderToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingIdProviderToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingIdProviderToken", this.getClass().getName());
         }
     }
 
@@ -683,13 +683,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingTimestampToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingTimestampToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingTimestampToken", this.getClass().getName());
         }
     }
 
@@ -700,13 +700,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken", this.getClass().getName());
         }
     }
 
@@ -717,13 +717,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMissingMacToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingMacToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingMacToken", this.getClass().getName());
         }
     }
 
@@ -734,13 +734,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleEmpty() {
         final String value = "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleEmpty", this.getClass().getName());
         }
     }
 
@@ -751,13 +751,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleBlank() {
         final String value = BLANK + "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleBlank", this.getClass().getName());
         }
     }
 
@@ -768,13 +768,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat() {
         final String value = "AAAAAA00011D000L/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -785,13 +785,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithNomeEmpty() {
         final String value = "AAAAAA00B77B000F/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -802,13 +802,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithNomeBlank() {
         final String value = "AAAAAA00B77B000F/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNomeBlank", this.getClass().getName());
         }
     }
 
@@ -819,13 +819,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCognomeEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + EMPTY + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCognomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCognomeEmpty", this.getClass().getName());
         }
     }
 
@@ -836,13 +836,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCognomeBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + BLANK + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCognomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCognomeBlank", this.getClass().getName());
         }
     }
 
@@ -853,13 +853,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithIdProviderEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + EMPTY + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithIdProviderEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithIdProviderEmpty", this.getClass().getName());
         }
     }
 
@@ -870,13 +870,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithIdProviderBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + BLANK + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithIdProviderBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithIdProviderBlank", this.getClass().getName());
         }
     }
 
@@ -887,13 +887,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithTimestampEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + EMPTY + "/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampEmpty", this.getClass().getName());
         }
     }
 
@@ -904,13 +904,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithTimestampBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + BLANK + "/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampBlank", this.getClass().getName());
         }
     }
 
@@ -921,13 +921,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithTimestampWithInvalidFormat() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/201605311139/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -938,13 +938,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + EMPTY + "/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty", this.getClass().getName());
         }
     }
 
@@ -955,13 +955,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + BLANK + "/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank", this.getClass().getName());
         }
     }
 
@@ -972,13 +972,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/A/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -989,13 +989,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/0/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange", this.getClass().getName());
         }
     }
 
@@ -1006,13 +1006,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/3/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange", this.getClass().getName());
         }
     }
 
@@ -1023,13 +1023,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMacEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacEmpty", this.getClass().getName());
         }
     }
 
@@ -1040,13 +1040,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMacBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacBlank", this.getClass().getName());
         }
     }
 
@@ -1057,13 +1057,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithMacOfInvalidLength() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacOfInvalidLength - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacOfInvalidLength", this.getClass().getName());
         }
     }
 
@@ -1074,13 +1074,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty() {
         final String value = "AAAAAA00011D000L/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -1091,13 +1091,13 @@ public final class IrideIdentityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank() {
         final String value = "AAAAAA00011D000L/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank", this.getClass().getName());
         }
     }
 
@@ -1114,13 +1114,13 @@ public final class IrideIdentityTest {
                              null + "/" +
                              null;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllNullTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllNullTokens", this.getClass().getName());
         }
     }
 
@@ -1137,13 +1137,13 @@ public final class IrideIdentityTest {
                              EMPTY + "/" +
                              EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllEmptyTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllEmptyTokens", this.getClass().getName());
         }
     }
 
@@ -1160,13 +1160,13 @@ public final class IrideIdentityTest {
                              BLANK + "/" +
                              BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllBlankTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllBlankTokens", this.getClass().getName());
         }
     }
 
@@ -1177,13 +1177,13 @@ public final class IrideIdentityTest {
     public void testIsValidIrideIdentity() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentity");
+        	LOGGER.trace("END {}::testIsValidIrideIdentity", this.getClass().getName());
         }
     }
 
@@ -1194,13 +1194,13 @@ public final class IrideIdentityTest {
     public void testIsValidIrideIdentityWithComplexMacToken() {
         final String value = "AAAAAA00A11D000L/CSI PIEMONTE/DEMO 23/IPA/20150223095441/2//VZjBdhZTwU+/7AUMNSHjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentityWithComplexMacToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken");
+        	LOGGER.trace("END {}::testIsValidIrideIdentityWithComplexMacToken", this.getClass().getName());
         }
     }
 
@@ -1211,13 +1211,13 @@ public final class IrideIdentityTest {
     public void testIsValidIrideIdentityWithRealisticDigitalIdentity() {
         final String value = "NNRLSN69P26L570X/Aldesino/Innerkofler/IPA/20160531113948/2//VZjBdhZTwU+/7AU0A8HjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentityWithRealisticDigitalIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity");
+        	LOGGER.trace("END {}::testIsValidIrideIdentityWithRealisticDigitalIdentity", this.getClass().getName());
         }
     }
 
@@ -1228,7 +1228,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentitySuccesfulSerialization() {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentitySuccesfulSerialization", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentitySuccesfulSerialization - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity = IrideIdentity.parseIrideIdentity(value);
 
@@ -1237,7 +1237,7 @@ public final class IrideIdentityTest {
             assertThat(serialized, is(not(nullValue())));
             assertThat(ArrayUtils.toObject(serialized), is(arrayWithSize(greaterThan(0))));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentitySuccesfulSerialization");
+        	LOGGER.trace("END {}::testIrideIdentitySuccesfulSerialization", this.getClass().getName());
         }
     }
 
@@ -1248,7 +1248,7 @@ public final class IrideIdentityTest {
     public void testIrideIdentitySuccesfulDeserialization() {
         final String value = StringUtils.join(this.tokens, IrideIdentityToken.SEPARATOR);
 
-        LOGGER.entering(this.getClass().getName(), "testIrideIdentitySuccesfulDeserialization", value);
+        LOGGER.trace("BEGIN {}::testIrideIdentitySuccesfulDeserialization - {}", this.getClass().getName(), value);
         try {
             final IrideIdentity irideIdentity1 = IrideIdentity.parseIrideIdentity(value);
 
@@ -1265,10 +1265,10 @@ public final class IrideIdentityTest {
             final IrideIdentity irideIdentity2 = (IrideIdentity) deserialized;
 
             assertThat(irideIdentity1, is(not(sameInstance(irideIdentity2))));
-            assertThat(irideIdentity1, is(irideIdentity2));
+            assertThat(irideIdentity1, is(equalTo(irideIdentity2)));
             assertThat(irideIdentity1.compareTo(irideIdentity2), is(0));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideIdentitySuccesfulDeserialization");
+        	LOGGER.trace("END {}::testIrideIdentitySuccesfulDeserialization", this.getClass().getName());
         }
     }
 

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTokenizerTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityTokenizerTest.java
@@ -23,14 +23,13 @@ import static org.geoserver.security.iride.Utils.BLANK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.entity.identity.IrideIdentityTokenizer;
 import org.geoserver.security.iride.entity.identity.exception.IrideIdentityMissingTokenException;
 import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 /**
  * {@link IrideIdentityTokenizer} <code>JUnit</code> Test Case.
@@ -66,11 +65,11 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationThrowNullPointerExceptionForNullValue() throws IrideIdentityMissingTokenException {
         final String value = null;
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationThrowNullPointerExceptionForNullValue", value);
+        LOGGER.trace("BEGIN {}::testTokenizationThrowNullPointerExceptionForNullValue - {}", this.getClass().getName(), IrideIdentityToken.SEPARATOR);
         try {
             this.tokenizer.tokenize(value);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationThrowNullPointerExceptionForNullValue");
+        	LOGGER.trace("END {}::testTokenizationThrowNullPointerExceptionForNullValue", this.getClass().getName());
         }
     }
 
@@ -83,7 +82,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForEmptyValue() throws IrideIdentityMissingTokenException {
         final String value = EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForEmptyValue", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForEmptyValue - {}", this.getClass().getName(), IrideIdentityToken.SEPARATOR);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -92,7 +91,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForEmptyValue");
+        	LOGGER.trace("END {}::testTokenizationFailForEmptyValue", this.getClass().getName());
         }
     }
 
@@ -105,7 +104,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForBlankValue() throws IrideIdentityMissingTokenException {
         final String value = BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForBlankValue", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForBlankValue - {}", this.getClass().getName(), IrideIdentityToken.SEPARATOR);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -114,7 +113,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForBlankValue");
+        	LOGGER.trace("END {}::testTokenizationFailForBlankValue", this.getClass().getName());
         }
     }
 
@@ -127,7 +126,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForUnrecognizedValue() throws IrideIdentityMissingTokenException {
         final String value = "UNRECOGNIZED_VALUE";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForUnrecognizedValue", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForUnrecognizedValue - {}", this.getClass().getName(), IrideIdentityToken.SEPARATOR);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -136,7 +135,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForUnrecognizedValue");
+        	LOGGER.trace("END {}::testTokenizationFailForUnrecognizedValue", this.getClass().getName());
         }
     }
 
@@ -149,7 +148,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingCodiceFiscaleToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingCodiceFiscaleToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingCodiceFiscaleToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -158,7 +157,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingCodiceFiscaleToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingCodiceFiscaleToken", this.getClass().getName());
         }
     }
 
@@ -171,7 +170,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingNomeToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingNomeToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingNomeToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -180,7 +179,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingNomeToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingNomeToken", this.getClass().getName());
         }
     }
 
@@ -193,7 +192,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingCognomeToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingCognomeToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingCognomeToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -202,7 +201,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingCognomeToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingCognomeToken", this.getClass().getName());
         }
     }
 
@@ -215,7 +214,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingIdProviderToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingIdProviderToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingIdProviderToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -224,7 +223,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingIdProviderToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingIdProviderToken", this.getClass().getName());
         }
     }
 
@@ -237,7 +236,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingTimestampToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingTimestampToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingTimestampToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -246,7 +245,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingTimestampToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingTimestampToken", this.getClass().getName());
         }
     }
 
@@ -259,7 +258,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingLivelloAutenticazioneToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingLivelloAutenticazioneToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingLivelloAutenticazioneToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -268,7 +267,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingLivelloAutenticazioneToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingLivelloAutenticazioneToken", this.getClass().getName());
         }
     }
 
@@ -281,7 +280,7 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationFailForMissingMacToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationFailForMissingMacToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationFailForMissingMacToken - {}", this.getClass().getName(), value);
         try {
             this.tokenizer.tokenize(value);
         } catch (IrideIdentityMissingTokenException e) {
@@ -290,7 +289,7 @@ public final class IrideIdentityTokenizerTest {
 
             throw e;
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationFailForMissingMacToken");
+        	LOGGER.trace("END {}::testTokenizationFailForMissingMacToken", this.getClass().getName());
         }
     }
 
@@ -303,14 +302,14 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationSuccessful() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationSuccessful", value);
+        LOGGER.trace("BEGIN {}::testTokenizationSuccessful - {}", this.getClass().getName(), value);
         try {
             final String[] result = this.tokenizer.tokenize(value);
 
             assertThat(result, is(arrayWithSize(IrideIdentityToken.values().length)));
             assertThat(result, is(arrayContaining("AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==")));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationSuccessful");
+        	LOGGER.trace("END {}::testTokenizationSuccessful", this.getClass().getName());
         }
     }
 
@@ -323,14 +322,14 @@ public final class IrideIdentityTokenizerTest {
     public void testTokenizationSuccessfulForComplexMacToken() throws IrideIdentityMissingTokenException {
         final String value = "AAAAAA00A11D000L/CSI PIEMONTE/DEMO 23/IPA/20150223095441/2//VZjBdhZTwU+/7AUMNSHjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testTokenizationSuccessfulForComplexMacToken", value);
+        LOGGER.trace("BEGIN {}::testTokenizationSuccessfulForComplexMacToken - {}", this.getClass().getName(), value);
         try {
             final String[] result = this.tokenizer.tokenize(value);
 
             assertThat(result, is(arrayWithSize(IrideIdentityToken.values().length)));
             assertThat(result, is(arrayContaining("AAAAAA00A11D000L", "CSI PIEMONTE", "DEMO 23", "IPA", "20150223095441", "2", "/VZjBdhZTwU+/7AUMNSHjQ==")));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testTokenizationSuccessfulForComplexMacToken");
+        	LOGGER.trace("END {}::testTokenizationSuccessfulForComplexMacToken", this.getClass().getName());
         }
     }
 

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityValidatorTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/identity/IrideIdentityValidatorTest.java
@@ -23,8 +23,6 @@ import static org.geoserver.security.iride.Utils.BLANK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.entity.identity.IrideIdentityValidator;
 import org.geoserver.security.iride.entity.identity.token.IrideIdentityToken;
 import org.geoserver.security.iride.entity.identity.token.value.IrideIdentityInvalidTokenValue;
@@ -32,6 +30,7 @@ import org.geoserver.security.iride.entity.util.Utils;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 /**
  * {@link IrideIdentityValidator} <code>JUnit</code> Test Case.
@@ -65,13 +64,13 @@ public final class IrideIdentityValidatorTest {
     public void testValidateSuccessful() {
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
 
-        LOGGER.entering(this.getClass().getName(), "testValidateSuccessful");
+        LOGGER.trace("BEGIN {}::testValidateSuccessful - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
             assertThat(result, is(emptyArray()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateSuccessful");
+        	LOGGER.trace("END {}::testValidateSuccessful", this.getClass().getName());
         }
     }
 
@@ -82,13 +81,13 @@ public final class IrideIdentityValidatorTest {
     public void testValidateSuccessfulForRealisticDigitalIdentity() {
         final String[] tokens = new String[] { "NNRLSN69P26L570X", "Aldesino", "Innerkofler", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
 
-        LOGGER.entering(this.getClass().getName(), "testValidateSuccessfulForRealisticCodiceFiscale");
+        LOGGER.trace("BEGIN {}::testValidateSuccessfulForRealisticDigitalIdentity - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
             assertThat(result, is(emptyArray()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateSuccessfulForRealisticCodiceFiscale");
+        	LOGGER.trace("END {}::testValidateSuccessfulForRealisticDigitalIdentity", this.getClass().getName());
         }
     }
 
@@ -99,11 +98,11 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForInvalidNullTokensArray() {
         final String[] tokens = null;
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidNullTokensArray");
+        LOGGER.trace("BEGIN {}::testValidateFailForInvalidNullTokensArray - {}", this.getClass().getName(), tokens);
         try {
             this.validator.validate(tokens);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidNullTokensArray");
+        	LOGGER.trace("END {}::testValidateFailForInvalidNullTokensArray", this.getClass().getName());
         }
     }
 
@@ -114,11 +113,11 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForInvalidEmptyTokensArray() {
         final String[] tokens = new String[0];
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidEmptyTokensArray");
+        LOGGER.trace("BEGIN {}::testValidateFailForInvalidEmptyTokensArray - {}", this.getClass().getName(), tokens);
         try {
             this.validator.validate(tokens);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidEmptyTokensArray");
+        	LOGGER.trace("END {}::testValidateFailForInvalidEmptyTokensArray", this.getClass().getName());
         }
     }
 
@@ -129,11 +128,11 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForInvalidLengthTokensArray() {
         final String[] tokens = new String[5];
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForInvalidLengthTokensArray");
+        LOGGER.trace("BEGIN {}::testValidateFailForInvalidLengthTokensArray - {}", this.getClass().getName(), tokens);
         try {
             this.validator.validate(tokens);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForInvalidLengthTokensArray");
+        	LOGGER.trace("END {}::testValidateFailForInvalidLengthTokensArray", this.getClass().getName());
         }
     }
 
@@ -144,7 +143,7 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForCodiceFiscaleNull() {
         final String[] tokens = new String[] { null, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleNull");
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -153,9 +152,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleNull");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleNull", this.getClass().getName());
         }
     }
 
@@ -166,7 +165,7 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForCodiceFiscaleBlank() {
         final String[] tokens = new String[] { BLANK, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleBlank");
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -175,9 +174,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleBlank");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleBlank", this.getClass().getName());
         }
     }
 
@@ -188,7 +187,7 @@ public final class IrideIdentityValidatorTest {
     public void testValidateFailForCodiceFiscaleEmpty() {
         final String[] tokens = new String[] { EMPTY, "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
 
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleEmpty");
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -197,9 +196,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleEmpty");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleEmpty", this.getClass().getName());
         }
     }
 
@@ -208,9 +207,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCodiceFiscaleWithInvalidFormat() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormat");
-
         final String[] tokens = new String[] { "AAAAAA00011D000L", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleWithInvalidFormat - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -219,9 +218,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.CODICE_FISCALE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.CODICE_FISCALE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormat");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -230,9 +229,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForNomeNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", null, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForNomeNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -241,9 +240,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeNull");
+        	LOGGER.trace("END {}::testValidateFailForNomeNull", this.getClass().getName());
         }
     }
 
@@ -252,9 +251,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForNomeBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", BLANK, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForNomeBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -263,9 +262,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeBlank");
+        	LOGGER.trace("END {}::testValidateFailForNomeBlank", this.getClass().getName());
         }
     }
 
@@ -274,9 +273,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForNomeEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForNomeEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", EMPTY, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForNomeEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -285,9 +284,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForNomeEmpty");
+        	LOGGER.trace("END {}::testValidateFailForNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -296,9 +295,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCognomeNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", null, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCognomeNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -307,9 +306,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeNull");
+        	LOGGER.trace("END {}::testValidateFailForCognomeNull", this.getClass().getName());
         }
     }
 
@@ -318,9 +317,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCognomeBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", BLANK, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCognomeBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -329,9 +328,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeBlank");
+        	LOGGER.trace("END {}::testValidateFailForCognomeNull", this.getClass().getName());
         }
     }
 
@@ -340,9 +339,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCognomeEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCognomeEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", EMPTY, "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCognomeEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -351,9 +350,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.COGNOME));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.COGNOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCognomeEmpty");
+        	LOGGER.trace("END {}::testValidateFailForCognomeEmpty", this.getClass().getName());
         }
     }
 
@@ -362,9 +361,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForIdProviderNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", null, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForIdProviderNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -373,9 +372,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderNull");
+        	LOGGER.trace("END {}::testValidateFailForIdProviderNull", this.getClass().getName());
         }
     }
 
@@ -384,9 +383,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForIdProviderBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", BLANK, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForIdProviderBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -395,9 +394,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderBlank");
+        	LOGGER.trace("END {}::testValidateFailForIdProviderBlank", this.getClass().getName());
         }
     }
 
@@ -406,9 +405,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForIdProviderEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForIdProviderEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", EMPTY, "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForIdProviderEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -417,9 +416,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.ID_PROVIDER));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.ID_PROVIDER.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForIdProviderEmpty");
+        	LOGGER.trace("END {}::testValidateFailForIdProviderEmpty", this.getClass().getName());
         }
     }
 
@@ -428,9 +427,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForTimestampNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", null, "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForTimestampNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -439,9 +438,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampNull");
+        	LOGGER.trace("END {}::testValidateFailForTimestampNull", this.getClass().getName());
         }
     }
 
@@ -450,9 +449,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForTimestampBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", BLANK, "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForTimestampBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -461,9 +460,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampBlank");
+        	LOGGER.trace("END {}::testValidateFailForTimestampBlank", this.getClass().getName());
         }
     }
 
@@ -472,9 +471,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForTimestampEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", EMPTY, "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForTimestampEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -483,9 +482,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampEmpty");
+        	LOGGER.trace("END {}::testValidateFailForTimestampEmpty", this.getClass().getName());
         }
     }
 
@@ -494,9 +493,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForTimestampWithInvalidFormat() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForTimestampWithInvalidFormat");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "201605311139", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForTimestampWithInvalidFormat - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -505,9 +504,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.TIMESTAMP));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.TIMESTAMP.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForTimestampWithInvalidFormat");
+        	LOGGER.trace("END {}::testValidateFailForTimestampWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -516,9 +515,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", null, "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -527,9 +526,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneNull");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneNull", this.getClass().getName());
         }
     }
 
@@ -538,9 +537,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", BLANK, "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -549,9 +548,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneBlank");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneBlank", this.getClass().getName());
         }
     }
 
@@ -560,9 +559,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", EMPTY, "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -571,9 +570,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneEmpty");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneEmpty", this.getClass().getName());
         }
     }
 
@@ -582,9 +581,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneWithInvalidFormat() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithInvalidFormat");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "A", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneWithInvalidFormat - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -593,9 +592,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithInvalidFormat");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -604,9 +603,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneWithValue0NotInRange() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue0NotInRange");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "0", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneWithValue0NotInRange - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -615,9 +614,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue0NotInRange");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneWithValue0NotInRange", this.getClass().getName());
         }
     }
 
@@ -626,9 +625,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForLivelloAutenticazioneWithValue3NotInRange() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue3NotInRange");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "3", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForLivelloAutenticazioneWithValue3NotInRange - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -637,9 +636,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.LIVELLO_AUTENTICAZIONE));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.LIVELLO_AUTENTICAZIONE.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForLivelloAutenticazioneWithValue3NotInRange");
+        	LOGGER.trace("END {}::testValidateFailForLivelloAutenticazioneWithValue3NotInRange", this.getClass().getName());
         }
     }
 
@@ -648,9 +647,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForMacNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacNull");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", null };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForMacNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -659,9 +658,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacNull");
+        	LOGGER.trace("END {}::testValidateFailForMacNull", this.getClass().getName());
         }
     }
 
@@ -670,9 +669,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForMacBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacBlank");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", BLANK };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForMacBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -681,9 +680,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacBlank");
+        	LOGGER.trace("END {}::testValidateFailForMacBlank", this.getClass().getName());
         }
     }
 
@@ -692,9 +691,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForMacEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", EMPTY };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForMacEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -703,9 +702,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacEmpty");
+        	LOGGER.trace("END {}::testValidateFailForMacEmpty", this.getClass().getName());
         }
     }
 
@@ -714,9 +713,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForMacWithInvalidLenght() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForMacWithInvalidLenght");
-
         final String[] tokens = new String[] { "AAAAAA00B77B000F", "CSI PIEMONTE", "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForMacWithInvalidLenght - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -725,9 +724,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[0].getToken(), is(IrideIdentityToken.MAC));
             assertThat(result[0].getValue(), is(tokens[IrideIdentityToken.MAC.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForMacWithInvalidLenght");
+        	LOGGER.trace("END {}::testValidateFailForMacWithInvalidLenght", this.getClass().getName());
         }
     }
 
@@ -736,9 +735,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull");
-
         final String[] tokens = new String[] { "AAAAAA00011D000L", null, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -749,9 +748,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeNull", this.getClass().getName());
         }
     }
 
@@ -760,9 +759,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank");
-
         final String[] tokens = new String[] { "AAAAAA00011D000L", BLANK, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -773,9 +772,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeBlank", this.getClass().getName());
         }
     }
 
@@ -784,9 +783,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty");
-
         final String[] tokens = new String[] { "AAAAAA00011D000L", EMPTY, "DEMO 20", "IPA", "20160531113948", "2", "1IQssTaf4vNMa66qU52m7g==" };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -797,9 +796,9 @@ public final class IrideIdentityValidatorTest {
             assertThat(result[1].getToken(), is(IrideIdentityToken.NOME));
             assertThat(result[1].getValue(), is(tokens[IrideIdentityToken.NOME.getPosition()]));
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty");
+        	LOGGER.trace("END {}::testValidateFailForCodiceFiscaleWithInvalidFormatAndForNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -808,9 +807,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForAllNullTokens() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllNullTokens");
-
         final String[] tokens = new String[] { null, null, null, null, null, null, null };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForAllNullTokens - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -824,9 +823,9 @@ public final class IrideIdentityValidatorTest {
                 assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
             }
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllNullTokens");
+        	LOGGER.trace("END {}::testValidateFailForAllNullTokens", this.getClass().getName());
         }
     }
 
@@ -835,9 +834,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForAllBlankTokens() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllBlankTokens");
-
         final String[] tokens = new String[] { BLANK, BLANK, BLANK, BLANK, BLANK, BLANK, BLANK };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForAllBlankTokens - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -851,9 +850,9 @@ public final class IrideIdentityValidatorTest {
                 assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
             }
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllBlankTokens");
+        	LOGGER.trace("END {}::testValidateFailForAllBlankTokens", this.getClass().getName());
         }
     }
 
@@ -862,9 +861,9 @@ public final class IrideIdentityValidatorTest {
      */
     @Test
     public void testValidateFailForAllEmptyTokens() {
-        LOGGER.entering(this.getClass().getName(), "testValidateFailForAllEmptyTokens");
-
         final String[] tokens = new String[] { EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY };
+
+        LOGGER.trace("BEGIN {}::testValidateFailForAllEmptyTokens - {}", this.getClass().getName(), tokens);
         try {
             final IrideIdentityInvalidTokenValue[] result = this.validator.validate(tokens);
 
@@ -878,9 +877,9 @@ public final class IrideIdentityValidatorTest {
                 assertThat(result[i].getValue(), is(tokens[irideIdentityTokens[i].getPosition()]));
             }
 
-            LOGGER.warning(Utils.toString(result));
+            LOGGER.warn(Utils.toString(result));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testValidateFailForAllEmptyTokens");
+        	LOGGER.trace("END {}::testValidateFailForAllEmptyTokens", this.getClass().getName());
         }
     }
 

--- a/security/iride-entities/src/test/java/org/geoserver/security/iride/util/IrideIdentityValidityTest.java
+++ b/security/iride-entities/src/test/java/org/geoserver/security/iride/util/IrideIdentityValidityTest.java
@@ -23,11 +23,10 @@ import static org.geoserver.security.iride.Utils.BLANK;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.entity.IrideIdentity;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Test;
+import org.slf4j.Logger;
 
 /**
  * <code>IRIDE</code> <code>Digital Identity</code> validity <code>JUnit</code> Test Case.
@@ -48,13 +47,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotInvalidIrideIdentity() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotInvalidIrideIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsNotInvalidIrideIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(false));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotInvalidIrideIdentity");
+            LOGGER.trace("END {}::testIsNotInvalidIrideIdentity", this.getClass().getName());
         }
     }
 
@@ -65,13 +64,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithNullValue() {
         final String value = null;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNullValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNullValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNullValue", this.getClass().getName());
         }
     }
 
@@ -82,13 +81,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithBlankValue() {
         final String value = BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithBlankValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithBlankValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithBlankValue", this.getClass().getName());
         }
     }
 
@@ -99,13 +98,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithEmptyValue() {
         final String value = EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithEmptyValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithEmptyValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithEmptyValue", this.getClass().getName());
         }
     }
 
@@ -116,13 +115,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithUnrecognizedValue() {
         final String value = "UNRECOGNIZED_VALUE";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithUnrecognizedValue - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithUnrecognizedValue");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithUnrecognizedValue", this.getClass().getName());
         }
     }
 
@@ -133,13 +132,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken() {
         final String value = "AAAAAA00B77B000F";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingCodiceFiscaleToken", this.getClass().getName());
         }
     }
 
@@ -150,13 +149,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingNomeToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingNomeToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingNomeToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingNomeToken", this.getClass().getName());
         }
     }
 
@@ -167,13 +166,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingCognomeToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingCognomeToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingCognomeToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingCognomeToken", this.getClass().getName());
         }
     }
 
@@ -184,13 +183,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingIdProviderToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingIdProviderToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingIdProviderToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingIdProviderToken", this.getClass().getName());
         }
     }
 
@@ -201,13 +200,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingTimestampToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingTimestampToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingTimestampToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingTimestampToken", this.getClass().getName());
         }
     }
 
@@ -218,13 +217,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingLivelloAutenticazioneToken", this.getClass().getName());
         }
     }
 
@@ -235,13 +234,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMissingMacToken() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMissingMacToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMissingMacToken");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMissingMacToken", this.getClass().getName());
         }
     }
 
@@ -252,13 +251,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleEmpty() {
         final String value = "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleEmpty", this.getClass().getName());
         }
     }
 
@@ -269,13 +268,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleBlank() {
         final String value = BLANK + "/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleBlank", this.getClass().getName());
         }
     }
 
@@ -286,13 +285,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat() {
         final String value = "AAAAAA00011D000L/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -303,13 +302,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithNomeEmpty() {
         final String value = "AAAAAA00B77B000F/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -320,13 +319,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithNomeBlank() {
         final String value = "AAAAAA00B77B000F/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithNomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithNomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithNomeBlank", this.getClass().getName());
         }
     }
 
@@ -337,13 +336,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCognomeEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + EMPTY + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCognomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCognomeEmpty", this.getClass().getName());
         }
     }
 
@@ -354,13 +353,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCognomeBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/" + BLANK + "/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCognomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCognomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCognomeBlank", this.getClass().getName());
         }
     }
 
@@ -371,13 +370,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithIdProviderEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + EMPTY + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithIdProviderEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithIdProviderEmpty", this.getClass().getName());
         }
     }
 
@@ -388,13 +387,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithIdProviderBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/" + BLANK + "/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithIdProviderBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithIdProviderBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithIdProviderBlank", this.getClass().getName());
         }
     }
 
@@ -405,13 +404,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithTimestampEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + EMPTY + "/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampEmpty", this.getClass().getName());
         }
     }
 
@@ -422,13 +421,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithTimestampBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/" + BLANK + "/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampBlank", this.getClass().getName());
         }
     }
 
@@ -439,13 +438,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithTimestampWithInvalidFormat() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/201605311139/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithTimestampWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithTimestampWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithTimestampWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -456,13 +455,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + EMPTY + "/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneEmpty", this.getClass().getName());
         }
     }
 
@@ -473,13 +472,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/" + BLANK + "/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneBlank", this.getClass().getName());
         }
     }
 
@@ -490,13 +489,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/A/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneWithInvalidFormat", this.getClass().getName());
         }
     }
 
@@ -507,13 +506,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/0/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue0NotInRange", this.getClass().getName());
         }
     }
 
@@ -524,13 +523,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/3/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithLivelloAutenticazioneValue3NotInRange", this.getClass().getName());
         }
     }
 
@@ -541,13 +540,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMacEmpty() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacEmpty", this.getClass().getName());
         }
     }
 
@@ -558,13 +557,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMacBlank() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/" + BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacBlank", this.getClass().getName());
         }
     }
 
@@ -575,13 +574,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithMacOfInvalidLength() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithMacOfInvalidLength - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithMacOfInvalidLength");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithMacOfInvalidLength", this.getClass().getName());
         }
     }
 
@@ -592,13 +591,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty() {
         final String value = "AAAAAA00011D000L/" + EMPTY + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeEmpty", this.getClass().getName());
         }
     }
 
@@ -609,13 +608,13 @@ public final class IrideIdentityValidityTest {
     public void testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank() {
         final String value = "AAAAAA00011D000L/" + BLANK + "/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithCodiceFiscaleWithInvalidFormatAndWithNomeBlank", this.getClass().getName());
         }
     }
 
@@ -632,13 +631,13 @@ public final class IrideIdentityValidityTest {
                              null + "/" +
                              null;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllNullTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllNullTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllNullTokens", this.getClass().getName());
         }
     }
 
@@ -655,13 +654,13 @@ public final class IrideIdentityValidityTest {
                              EMPTY + "/" +
                              EMPTY;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllEmptyTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllEmptyTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllEmptyTokens", this.getClass().getName());
         }
     }
 
@@ -678,13 +677,13 @@ public final class IrideIdentityValidityTest {
                              BLANK + "/" +
                              BLANK;
 
-        LOGGER.entering(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens", value);
+        LOGGER.trace("BEGIN {}::testIsNotValidIrideIdentityWithAllBlankTokens - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isNotValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsNotValidIrideIdentityWithAllBlankTokens");
+        	LOGGER.trace("END {}::testIsNotValidIrideIdentityWithAllBlankTokens", this.getClass().getName());
         }
     }
 
@@ -695,13 +694,13 @@ public final class IrideIdentityValidityTest {
     public void testIsValidIrideIdentity() {
         final String value = "AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentity");
+        	LOGGER.trace("END {}::testIsValidIrideIdentity", this.getClass().getName());
         }
     }
 
@@ -712,13 +711,13 @@ public final class IrideIdentityValidityTest {
     public void testIsValidIrideIdentityWithComplexMacToken() {
         final String value = "AAAAAA00A11D000L/CSI PIEMONTE/DEMO 23/IPA/20150223095441/2//VZjBdhZTwU+/7AUMNSHjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentityWithComplexMacToken - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithComplexMacToken");
+        	LOGGER.trace("END {}::testIsValidIrideIdentityWithComplexMacToken", this.getClass().getName());
         }
     }
 
@@ -729,13 +728,13 @@ public final class IrideIdentityValidityTest {
     public void testIsValidIrideIdentityWithRealisticDigitalIdentity() {
         final String value = "NNRLSN69P26L570X/Aldesino/Innerkofler/IPA/20160531113948/2//VZjBdhZTwU+/7AU0A8HjQ==";
 
-        LOGGER.entering(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity", value);
+        LOGGER.trace("BEGIN {}::testIsValidIrideIdentityWithRealisticDigitalIdentity - {}", this.getClass().getName(), value);
         try {
             final boolean result = IrideIdentity.isValidIrideIdentity(value);
 
             assertThat(result, is(true));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIsValidIrideIdentityWithRealisticDigitalIdentity");
+        	LOGGER.trace("END {}::testIsValidIrideIdentityWithRealisticDigitalIdentity", this.getClass().getName());
         }
     }
 

--- a/security/iride-entities/src/test/resources/conf/logging.properties
+++ b/security/iride-entities/src/test/resources/conf/logging.properties
@@ -9,11 +9,4 @@ log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - 
 
 # === Specific levels === BEGIN ===
 log4j.category.org.geoserver.security.iride=ALL
-
-log4j.category.it.geosolutions=DEBUG
-
-log4j.category.org.geotools=ERROR
-log4j.category.org.geoserver=ERROR
-
-log4j.category.org.springframework=ERROR
 # === Specific levels ===   END ===

--- a/security/iride-service-client/pom.xml
+++ b/security/iride-service-client/pom.xml
@@ -356,7 +356,7 @@
                     <systemProperties>
                         <property>
                             <name>log4j.configuration</name>
-                            <value>src/test/resources/conf/logging.properties</value>
+                            <value>conf/logging.properties</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/security/iride-service-client/pom.xml
+++ b/security/iride-service-client/pom.xml
@@ -355,7 +355,7 @@
                     <testFailureIgnore>${test.allow.failure.ignore}</testFailureIgnore>
                     <systemProperties>
                         <property>
-                            <name>java.util.logging.config.file</name>
+                            <name>log4j.configuration</name>
                             <value>src/test/resources/conf/logging.properties</value>
                         </property>
                     </systemProperties>

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/IrideServiceImpl.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/IrideServiceImpl.java
@@ -25,8 +25,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.xml.transform.TransformerException;
 
@@ -39,6 +37,7 @@ import org.geoserver.security.iride.entity.IrideUseCase;
 import org.geoserver.security.iride.service.policy.IridePolicy;
 import org.geoserver.security.iride.service.policy.IridePolicyManager;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
 
@@ -82,7 +81,7 @@ public final class IrideServiceImpl implements IrideService {
     /**
      * Policy execution result message format.
      */
-    private static final String RESULT_MESSAGE_FORMAT = "IRIDE Policy '%s' result: %s: ";
+    private static final String RESULT_MESSAGE_FORMAT = "IRIDE Policy '{}' result: {}: ";
 
     /**
      * Policy execution error message format.
@@ -153,7 +152,7 @@ public final class IrideServiceImpl implements IrideService {
                 result = policyResult.toArray(new IrideRole[policyResult.size()]);
             }
         } catch (IOException | TransformerException e) {
-            LOGGER.log(Level.SEVERE, String.format(ERROR_MESSAGE_FORMAT, policy.getServiceName(), e.getMessage()), e);
+            LOGGER.error(ERROR_MESSAGE_FORMAT, new Object[] { policy.getServiceName(), e.getMessage(), e });
         }
 
         logPolicyExecutionResult(policy, result);
@@ -194,7 +193,7 @@ public final class IrideServiceImpl implements IrideService {
                 result = policyResult.toArray(new IrideUseCase[policyResult.size()]);
             }
         } catch (IOException | TransformerException e) {
-            LOGGER.log(Level.SEVERE, String.format(ERROR_MESSAGE_FORMAT, policy.getServiceName(), e.getMessage()), e);
+        	LOGGER.error(ERROR_MESSAGE_FORMAT, new Object[] { policy.getServiceName(), e.getMessage(), e });
         }
 
         logPolicyExecutionResult(policy, result);
@@ -222,7 +221,7 @@ public final class IrideServiceImpl implements IrideService {
                 result = (IrideIdentity) this.handleResponse(policy, policyResponse);
             }
         } catch (IOException | TransformerException e) {
-            LOGGER.log(Level.SEVERE, String.format(ERROR_MESSAGE_FORMAT, policy.getServiceName(), e.getMessage()), e);
+        	LOGGER.error(ERROR_MESSAGE_FORMAT, new Object[] { policy.getServiceName(), e.getMessage(), e });
         }
 
         logPolicyExecutionResult(policy, result);
@@ -281,7 +280,7 @@ public final class IrideServiceImpl implements IrideService {
                 result = (List<IrideInfoPersona>) this.handleResponse(policy, policyResponse);
             }
         } catch (IOException | TransformerException e) {
-            LOGGER.log(Level.SEVERE, String.format(ERROR_MESSAGE_FORMAT, policy.getServiceName(), e.getMessage()), e);
+        	LOGGER.error(ERROR_MESSAGE_FORMAT, new Object[] { policy.getServiceName(), e.getMessage(), e });
         }
 
         logPolicyExecutionResult(policy, result);
@@ -308,10 +307,10 @@ public final class IrideServiceImpl implements IrideService {
      * @param result the execution result
      */
     private static void logPolicyExecutionResult(IridePolicy policy, Object result) {
-        LOGGER.finest(String.format(
+        LOGGER.trace(
             RESULT_MESSAGE_FORMAT,
             policy.getServiceName(),
-            result instanceof Object[] ? Arrays.toString((Object[]) result) : result)
+            result instanceof Object[] ? Arrays.toString((Object[]) result) : result
         );
     }
 

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/IridePolicyManager.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/IridePolicyManager.java
@@ -18,11 +18,10 @@
  */
 package org.geoserver.security.iride.service.policy;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.service.policy.handler.IridePolicyRequestHandler;
 import org.geoserver.security.iride.service.policy.handler.IridePolicyResponseHandler;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 /**
  * Manager class for <code>IRIDE</code> service "policy" handlers.
@@ -89,7 +88,7 @@ public class IridePolicyManager {
     public IridePolicyRequestHandler getPolicyRequestHandler(IridePolicy policy) {
         final IridePolicyRequestHandler policyRequestHandler = this.getPolicyRequestHandlers().lookup(policy);
 
-        LOGGER.finest(String.format("Request Handler for IRIDE Policy '%s' found: %b", policy.getServiceName(), policyRequestHandler != null));
+        LOGGER.trace("Request Handler for IRIDE Policy '{}' found: {}", policy.getServiceName(), policyRequestHandler != null);
 
         return policyRequestHandler;
     }
@@ -141,7 +140,7 @@ public class IridePolicyManager {
     public IridePolicyResponseHandler getPolicyResponseHandler(IridePolicy policy) {
         final IridePolicyResponseHandler policyResponseHandler = this.getPolicyResponseHandlers().lookup(policy);
 
-        LOGGER.finest(String.format("Response Handler for IRIDE Policy '%s' found: %b", policy.getServiceName(), policyResponseHandler != null));
+        LOGGER.trace("Response Handler for IRIDE Policy '{}' found: {}", policy.getServiceName(), policyResponseHandler != null);
 
         return policyResponseHandler;
     }

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/IridePolicyRegistry.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/IridePolicyRegistry.java
@@ -21,11 +21,11 @@ package org.geoserver.security.iride.service.policy;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.geoserver.security.iride.service.policy.handler.AbstractIridePolicyHandler;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.geoserver.security.iride.util.object.ObjectRegistry;
+import org.slf4j.Logger;
 
 /**
  * Registry class for available <code>IRIDE</code> service "policy" handlers.
@@ -67,7 +67,7 @@ public final class IridePolicyRegistry<H extends AbstractIridePolicyHandler> ext
      */
     @Override
     protected void register(H[] policyHandlers) {
-        LOGGER.finest(String.format("Adding %d IRIDE Policy Handlers", policyHandlers.length));
+        LOGGER.trace("Adding {} IRIDE Policy Handlers", policyHandlers.length);
 
         super.register(policyHandlers);
     }
@@ -85,7 +85,7 @@ public final class IridePolicyRegistry<H extends AbstractIridePolicyHandler> ext
     protected void register(H policyHandler) {
         super.register(policyHandler);
 
-        LOGGER.finest(String.format("Added IRIDE Policy Handler '%s'", policyHandler.getObjectId().getServiceName()));
+        LOGGER.trace("Added IRIDE Policy Handler '{}'", policyHandler.getObjectId().getServiceName());
     }
 
     /* (non-Javadoc)

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/AbstractIridePolicyHandler.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/AbstractIridePolicyHandler.java
@@ -18,11 +18,10 @@
  */
 package org.geoserver.security.iride.service.policy.handler;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.service.policy.IridePolicy;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.geoserver.security.iride.util.object.RegistrableObject;
+import org.slf4j.Logger;
 
 /**
  * Base class for <code>IRIDE</code> service "policy" handlers.

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/IridePolicyRequestHandler.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/IridePolicyRequestHandler.java
@@ -156,10 +156,10 @@ public final class IridePolicyRequestHandler extends AbstractIridePolicyHandler 
             if (responseCode == HttpStatus.SC_OK ) {
                 result = responseXml;
             } else {
-                LOGGER.warning("IRIDE error response code: " + String.format("%d %s", responseCode, HttpStatus.getStatusText(responseCode)));
+                LOGGER.warn("IRIDE error response code: {} {}", responseCode, HttpStatus.getStatusText(responseCode));
             }
 
-            LOGGER.finest("IRIDE SOAP response: " + responseXml);
+            LOGGER.trace("IRIDE SOAP response: " + responseXml);
 
             return result;
         } finally {

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/IridePolicyResponseHandler.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/policy/handler/IridePolicyResponseHandler.java
@@ -145,7 +145,7 @@ public final class IridePolicyResponseHandler extends AbstractIridePolicyHandler
     public Object handleResponse(String policyResponse) throws TransformerException {
         final String policyResponseMarshalledXml = this.createPolicyResponseMarshalledXml(policyResponse);
 
-        LOGGER.finest("IRIDE Policy marshalled response: " + policyResponseMarshalledXml);
+        LOGGER.trace("IRIDE Policy marshalled response: {}", policyResponseMarshalledXml);
 
         return this.getXs().fromXML(policyResponseMarshalledXml);
     }

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/builder/http/HttpPostBuilder.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/builder/http/HttpPostBuilder.java
@@ -20,8 +20,6 @@ package org.geoserver.security.iride.service.util.builder.http;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.methods.PostMethod;
@@ -29,6 +27,7 @@ import org.apache.commons.httpclient.methods.RequestEntity;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.geoserver.security.iride.util.builder.Builder;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 import com.google.common.net.MediaType;
 
@@ -143,7 +142,7 @@ public class HttpPostBuilder implements Builder<PostMethod> {
         try {
             return this.createPostMethod();
         } catch (IOException e) {
-            LOGGER.log(Level.SEVERE, "HTTP POST method build failed: " + e.getMessage(), e);
+            LOGGER.error("HTTP POST method build failed: {}", e.getMessage(), e);
 
             return null;
         }

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/sax/SAXSourceFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/sax/SAXSourceFactory.java
@@ -66,7 +66,7 @@ public class SAXSourceFactory extends AbstractFactory<SAXSource> {
 
             return xmlReader;
         } catch (SAXException e) {
-            LOGGER.warning("SAX XMLReader creation error: " + e.getMessage());
+            LOGGER.warn("SAX XMLReader creation error: ", e.getMessage());
 
             return null;
         }
@@ -101,7 +101,7 @@ public class SAXSourceFactory extends AbstractFactory<SAXSource> {
         try {
             return resource.getURL().toURI().toString();
         } catch (IOException | URISyntaxException e) {
-            LOGGER.warning(String.format("Could not get System ID from [%s], error: %s", resource, e.getMessage()));
+            LOGGER.warn("Could not get System ID from [{}], error: {}", resource, e.getMessage());
 
             return null;
         }

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactory.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/factory/xstream/XStreamFactory.java
@@ -181,20 +181,20 @@ public class XStreamFactory extends AbstractFactory<XStream> {
         xs.setMode(XStream.NO_REFERENCES);
 
         // Aliases for IRIDE entities
-        LOGGER.finest(String.format("IRIDE XStream: aliasing %d types", this.getAliases().size()));
+        LOGGER.trace("IRIDE XStream: aliasing {} types", this.getAliases().size());
         for (final Entry<String, Class<?>> entry : this.getAliases().entrySet()) {
             xs.alias(entry.getKey(), entry.getValue());
 
-            LOGGER.finest(String.format("IRIDE XStream: aliased %s to '%s'", entry.getValue(), entry.getKey()));
+            LOGGER.trace("IRIDE XStream: aliased {} to '{}'", entry.getValue(), entry.getKey());
         }
 
         // Allowed types
         final Collection<Class<?>> types = this.getAliases().values();
-        LOGGER.finest(String.format("IRIDE XStream: allowing %d types", types.size()));
+        LOGGER.trace("IRIDE XStream: allowing {} types", types.size());
         xs.allowTypes(types.toArray(new Class<?>[types.size()]));
 
         // Custom converters for IRIDE entities
-        LOGGER.finest(String.format("IRIDE XStream: registering %d converters", this.converters.size()));
+        LOGGER.trace("IRIDE XStream: registering {} converters", this.converters.size());
         for (final ConverterMatcher converter : this.converters) {
             if (converter instanceof Converter) {
                 xs.registerConverter((Converter) converter);
@@ -202,7 +202,7 @@ public class XStreamFactory extends AbstractFactory<XStream> {
                 xs.registerConverter((SingleValueConverter) converter);
             }
 
-            LOGGER.finest(String.format("IRIDE XStream: registered %s converter", converter.getClass()));
+            LOGGER.trace("IRIDE XStream: registered {} converter", converter.getClass());
         }
 
         return xs;

--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/template/impl/freemarker/FreeMarkerTemplateEngine.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/util/template/impl/freemarker/FreeMarkerTemplateEngine.java
@@ -21,12 +21,12 @@ package org.geoserver.security.iride.service.util.template.impl.freemarker;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.logging.Logger;
 
 import org.geoserver.security.iride.util.io.Filename;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.geoserver.security.iride.util.template.TemplateEngine;
 import org.geoserver.security.iride.util.template.TemplateEngineException;
+import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
 
@@ -100,7 +100,7 @@ public final class FreeMarkerTemplateEngine implements TemplateEngine {
     public void process(String template, Object context, Writer writer) throws IOException {
         final Template freeMarkerTemplate = this.getTemplate(template);
 
-        LOGGER.finest("Processing template '" + template + "':\n" + freeMarkerTemplate + "\nwith context:\n" + context);
+        LOGGER.trace("Processing template '{}':\n{}\nwith context:\n{}", new Object[] { template, freeMarkerTemplate, context });
 
         try {
             freeMarkerTemplate.process(context == null ? TemplateModel.NOTHING : context, writer);
@@ -125,7 +125,7 @@ public final class FreeMarkerTemplateEngine implements TemplateEngine {
 
         final String output = writer.toString();
 
-        LOGGER.finest("Processed template '" + template + "':\n" + output);
+        LOGGER.trace("Processed template '{}':\n{}", template, output);
 
         return output;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/AbstractXmlUnitTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/AbstractXmlUnitTest.java
@@ -19,10 +19,10 @@
 package org.geoserver.security.iride;
 
 import java.util.Map;
-import java.util.logging.Logger;
 
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.hamcrest.Matcher;
+import org.slf4j.Logger;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.xmlunit.builder.DiffBuilder;

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/AbstractXStreamTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/AbstractXStreamTest.java
@@ -18,10 +18,9 @@
  */
 package org.geoserver.security.iride.entity.converter;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideApplicationConverterTest.java
@@ -77,7 +77,7 @@ public final class IrideApplicationConverterTest extends AbstractXStreamTest {
 
         assertThat(result, not(isEmptyOrNullString()));
 
-        this.logger.fine("Marshalling result:\n" + result);
+        this.logger.trace("Marshalling result:\n{}", result);
     }
 
     /**
@@ -90,7 +90,7 @@ public final class IrideApplicationConverterTest extends AbstractXStreamTest {
         assertThat(result, is(not(nullValue())));
         assertThat(result, is(this.application));
 
-        this.logger.fine("Unmarshalling result:\n" + result);
+        this.logger.trace("Unmarshalling result:\n{}", result);
     }
 
 }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideIdentityConverterTest.java
@@ -73,7 +73,7 @@ public final class IrideIdentityConverterTest extends AbstractXStreamTest {
 
         assertThat(result, not(isEmptyOrNullString()));
 
-        this.logger.fine("Marshalling result:\n" + result);
+        this.logger.trace("Marshalling result:\n{}", result);
     }
 
     /**
@@ -86,7 +86,7 @@ public final class IrideIdentityConverterTest extends AbstractXStreamTest {
         assertThat(result, is(not(nullValue())));
         assertThat(result, is(this.irideIdentity));
 
-        this.logger.fine("Unmarshalling result:\n" + result);
+        this.logger.trace("Unmarshalling result:\n{}", result);
     }
 
 }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideInfoPersonaConverterTest.java
@@ -86,7 +86,7 @@ public final class IrideInfoPersonaConverterTest extends AbstractXStreamTest {
 
         assertThat(result, not(isEmptyOrNullString()));
 
-        this.logger.fine("Marshalling result:\n" + result);
+        this.logger.trace("Marshalling result:\n{}", result);
     }
 
     /**
@@ -101,7 +101,7 @@ public final class IrideInfoPersonaConverterTest extends AbstractXStreamTest {
         assertThat(result.size(), is(1));
         assertThat(result.get(0), is(this.infoPersona));
 
-        this.logger.fine("Unmarshalling result:\n" + result);
+        this.logger.trace("Unmarshalling result:\n{}", result);
     }
 
 }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideRoleConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideRoleConverterTest.java
@@ -81,7 +81,7 @@ public final class IrideRoleConverterTest extends AbstractXStreamTest {
 
         assertThat(result, not(isEmptyOrNullString()));
 
-        this.logger.fine("Marshalling result:\n" + result);
+        this.logger.trace("Marshalling result:\n{}", result);
     }
 
     /**
@@ -96,7 +96,7 @@ public final class IrideRoleConverterTest extends AbstractXStreamTest {
         assertThat(result.size(), is(1));
         assertThat(result.get(0), is(this.role));
 
-        this.logger.fine("Unmarshalling result:\n" + result);
+        this.logger.trace("Unmarshalling result:\n{}", result);
     }
 
 }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverterTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/entity/converter/IrideUseCaseConverterTest.java
@@ -84,7 +84,7 @@ public final class IrideUseCaseConverterTest extends AbstractXStreamTest {
 
         assertThat(result, not(isEmptyOrNullString()));
 
-        this.logger.fine("Marshalling result:\n" + result);
+        this.logger.trace("Marshalling result:\n{}", result);
     }
 
     /**
@@ -99,7 +99,7 @@ public final class IrideUseCaseConverterTest extends AbstractXStreamTest {
         assertThat(result.size(), is(7));
         assertThat(result.get(0), is(this.useCase));
 
-        this.logger.fine("Unmarshalling result:\n" + result);
+        this.logger.trace("Unmarshalling result:\n{}", result);
     }
 
 }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/response/IridePolicyResponseHandlerTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/service/policy/handler/response/IridePolicyResponseHandlerTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.logging.Logger;
 
 import javax.xml.transform.TransformerException;
 
@@ -39,6 +38,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -153,7 +153,7 @@ public final class IridePolicyResponseHandlerTest {
 
         assertThat(result, not(nullValue()));
 
-        LOGGER.fine(String.format("Policy '%s' Response Object: %s", this.policy, result));
+        LOGGER.trace("Policy '{}' Response Object: {}", this.policy, result);
     }
 
     /**

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/AbstractIrideSoapRequestTemplateCompilationTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/soap/request/iride/AbstractIrideSoapRequestTemplateCompilationTest.java
@@ -145,14 +145,14 @@ public abstract class AbstractIrideSoapRequestTemplateCompilationTest extends Ab
 
         final Writer out = new StringWriter();
 
-        logger.fine("IRIDE SOAP request '" + this.getTemplateName() + "' template: \n" + template);
-        logger.fine("IRIDE SOAP request '" + this.getTemplateName() + "' dataModel: \n" + dataModel);
+        logger.trace("IRIDE SOAP request '{}' template: \n{}", this.getTemplateName(), template);
+        logger.trace("IRIDE SOAP request '{}' dataModel: \n{}", this.getTemplateName(), dataModel);
 
         template.process(dataModel, out);
 
         final String output = out.toString();
 
-        logger.fine("IRIDE SOAP request '" + this.getTemplateName() + "' template processing output: \n" + output);
+        logger.trace("IRIDE SOAP request '{}' template processing output: \n{}", this.getTemplateName(), output);
 
         return output;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerConfigurationDefaultFactoryTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerConfigurationDefaultFactoryTest.java
@@ -27,13 +27,13 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.security.iride.service.util.factory.template.freemarker.FreeMarkerConfigurationFactory;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -76,7 +76,7 @@ public final class FreeMarkerConfigurationDefaultFactoryTest {
      */
     @Test
     public void testCreateConfiguration() throws IOException, URISyntaxException {
-        LOGGER.entering(this.getClass().getName(), "testCreateConfiguration");
+    	LOGGER.trace("BEGIN {}::testCreateConfiguration", this.getClass().getName());
         try {
             final Configuration templateConfiguration = FreeMarkerConfigurationFactory.createConfiguration();
 
@@ -104,7 +104,7 @@ public final class FreeMarkerConfigurationDefaultFactoryTest {
             // FreeMarker TemplateExceptionHandler Configuration
             assertThat(templateConfiguration.getTemplateExceptionHandler(), is(TemplateExceptionHandler.RETHROW_HANDLER));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testCreateConfiguration");
+        	LOGGER.trace("END {}::testCreateConfiguration", this.getClass().getName());
         }
     }
 
@@ -116,7 +116,7 @@ public final class FreeMarkerConfigurationDefaultFactoryTest {
      */
     @Test
     public void testCreate() throws IOException, URISyntaxException {
-        LOGGER.entering(this.getClass().getName(), "testCreate");
+        LOGGER.trace("BEGIN {}::testCreate", this.getClass().getName());
         try {
             final Configuration templateConfiguration = this.templateConfigurationFactory.create();
 
@@ -144,7 +144,7 @@ public final class FreeMarkerConfigurationDefaultFactoryTest {
             // FreeMarker TemplateExceptionHandler Configuration
             assertThat(templateConfiguration.getTemplateExceptionHandler(), is(TemplateExceptionHandler.RETHROW_HANDLER));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testCreate");
+        	LOGGER.trace("END {}::testCreate", this.getClass().getName());
         }
     }
 

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerTemplateEngineFactoryTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/factory/template/freemarker/FreeMarkerTemplateEngineFactoryTest.java
@@ -27,7 +27,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.security.iride.service.util.factory.template.freemarker.FreeMarkerConfigurationFactory;
@@ -38,6 +37,7 @@ import org.geoserver.security.iride.util.template.TemplateEngine;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -88,7 +88,7 @@ public final class FreeMarkerTemplateEngineFactoryTest {
      */
     @Test
     public void testCreateTemplateEngineConfiguration() throws IOException, URISyntaxException {
-        LOGGER.entering(this.getClass().getName(), "testCreateTemplateEngineConfiguration");
+    	LOGGER.trace("BEGIN {}::testCreateTemplateEngineConfiguration", this.getClass().getName());
         try {
             final FreeMarkerTemplateEngine templateEngine = FreeMarkerTemplateEngineFactory.createTemplateEngine(this.defaultConfiguration);
 
@@ -123,7 +123,7 @@ public final class FreeMarkerTemplateEngineFactoryTest {
             // FreeMarker Template Extension
             assertThat(templateEngine.getTemplateExtension(), is(nullValue()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testCreateTemplateEngineConfiguration");
+        	LOGGER.trace("END {}::testCreateTemplateEngineConfiguration", this.getClass().getName());
         }
     }
 
@@ -135,7 +135,7 @@ public final class FreeMarkerTemplateEngineFactoryTest {
      */
     @Test
     public void testCreateTemplateEngineConfigurationWithExtension() throws IOException, URISyntaxException {
-        LOGGER.entering(this.getClass().getName(), "testCreateTemplateEngineConfigurationWithExtension");
+    	LOGGER.trace("BEGIN {}::testCreateTemplateEngineConfigurationWithExtension", this.getClass().getName());
         try {
             final FreeMarkerTemplateEngine templateEngine = FreeMarkerTemplateEngineFactory.createTemplateEngine(this.defaultConfiguration, "xml");
 
@@ -170,7 +170,7 @@ public final class FreeMarkerTemplateEngineFactoryTest {
             // FreeMarker Template Extension
             assertThat(templateEngine.getTemplateExtension(), is("xml"));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testCreateTemplateEngineConfigurationWithExtension");
+        	LOGGER.trace("END {}::testCreateTemplateEngineConfigurationWithExtension", this.getClass().getName());
         }
     }
 

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
@@ -89,7 +89,7 @@ public final class ErroneousXslProcessorTest extends AbstractOthersXslProcessorT
     protected String doTestXslProcessing() throws TransformerException {
         final String result = this.transform();
 
-        logger.trace("Transformation result:\n", result);
+        logger.trace("Transformation result:\n{}", result);
 
         return result;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ErroneousXslProcessorTest.java
@@ -89,7 +89,7 @@ public final class ErroneousXslProcessorTest extends AbstractOthersXslProcessorT
     protected String doTestXslProcessing() throws TransformerException {
         final String result = this.transform();
 
-        logger.fine("Transformation result:\n" + result);
+        logger.trace("Transformation result:\n", result);
 
         return result;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
@@ -72,7 +72,7 @@ public final class ParametrizedXslProcessorTest extends AbstractOthersXslProcess
     protected String doTestXslProcessing() throws TransformerException {
         final String result = this.transform();
 
-        logger.fine("Transformation result:\n" + result);
+        logger.trace("Transformation result:\n", result);
 
         return result;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/others/ParametrizedXslProcessorTest.java
@@ -72,7 +72,7 @@ public final class ParametrizedXslProcessorTest extends AbstractOthersXslProcess
     protected String doTestXslProcessing() throws TransformerException {
         final String result = this.transform();
 
-        logger.trace("Transformation result:\n", result);
+        logger.trace("Transformation result:\n{}", result);
 
         return result;
     }

--- a/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/AbstractIridePolicyResponseXslProcessorTest.java
+++ b/security/iride-service-client/src/test/java/org/geoserver/security/iride/util/xml/transform/policy/AbstractIridePolicyResponseXslProcessorTest.java
@@ -86,11 +86,11 @@ public abstract class AbstractIridePolicyResponseXslProcessorTest extends Abstra
      */
     @Override
     protected String doTestXslProcessing() throws TransformerException {
-        logger.fine("Processing " + this.policy.getServiceName() + " IRIDE policy response");
+        logger.trace("Processing {} IRIDE policy response", this.policy.getServiceName());
 
         final String result = this.transform();
 
-        logger.fine("Processed " + this.policy.getServiceName() + " IRIDE policy response result:\n" + result);
+        logger.trace("Processed {} IRIDE policy response result:\n", this.policy.getServiceName(), result);
 
         return result;
     }

--- a/security/sec-iride/pom.xml
+++ b/security/sec-iride/pom.xml
@@ -354,7 +354,7 @@
                     <testFailureIgnore>${test.allow.failure.ignore}</testFailureIgnore>
                     <systemProperties>
                         <property>
-                            <name>java.util.logging.config.file</name>
+                            <name>log4j.configuration</name>
                             <value>src/test/resources/conf/logging.properties</value>
                         </property>
                     </systemProperties>

--- a/security/sec-iride/pom.xml
+++ b/security/sec-iride/pom.xml
@@ -355,7 +355,7 @@
                     <systemProperties>
                         <property>
                             <name>log4j.configuration</name>
-                            <value>src/test/resources/conf/logging.properties</value>
+                            <value>conf/logging.properties</value>
                         </property>
                     </systemProperties>
                 </configuration>

--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideAuthenticationProvider.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideAuthenticationProvider.java
@@ -21,8 +21,6 @@ package org.geoserver.security.iride;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -35,6 +33,7 @@ import org.geoserver.security.iride.authentication.IridePolicyAuthenticationProv
 import org.geoserver.security.iride.config.IrideAuthenticationProviderConfig;
 import org.geoserver.security.iride.util.factory.security.IridePolicyAuthenticationProviderFactory;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -96,10 +95,7 @@ public class IrideAuthenticationProvider extends GeoServerAuthenticationProvider
      */
     @Override
     public void initializeFromConfig(SecurityNamedServiceConfig config) throws IOException {
-        LOGGER.log(Level.CONFIG,
-            "Initializing {0} with configuration object: \n\t {1}",
-            new Object[] { this.getClass().getSimpleName(), config }
-        );
+        LOGGER.debug("Initializing {} with configuration object: \n\t {}", this.getClass().getSimpleName(), config);
 
         this.config = new Config(config);
 
@@ -129,34 +125,17 @@ public class IrideAuthenticationProvider extends GeoServerAuthenticationProvider
         UsernamePasswordAuthenticationToken auth = null;
         try {
             auth = (UsernamePasswordAuthenticationToken) this.delegateAuthProvider.authenticate(authentication);
+        } catch (UsernameNotFoundException | BadCredentialsException | DisabledException e) {
+        	LOGGER.trace(e.getMessage(), e);
         } catch (AuthenticationException e) {
-            this.log(e);
+        	LOGGER.warn(e.getMessage(), e);
         }
 
         final Authentication authToken = this.buildAuthenticationToken(auth);
 
-        LOGGER.fine("Authentication Token: " + authToken);
+        LOGGER.trace("Authentication Token: {}", authToken);
 
         return authToken;
-    }
-
-    /**
-     * Overridden to log with this Authentication Provider {@link #LOGGER}.
-     */
-    /*
-     * (non-Javadoc)
-     * @see org.geoserver.security.GeoServerAuthenticationProvider#log(org.springframework.security.core.AuthenticationException)
-     */
-    @Override
-    protected void log(AuthenticationException ex) {
-        Level l = Level.WARNING;
-        if (ex instanceof UsernameNotFoundException ||
-            ex instanceof BadCredentialsException ||
-            ex instanceof DisabledException) {
-            l = Level.FINE;
-        }
-
-        LOGGER.log(l, ex.getLocalizedMessage(), ex);
     }
 
     /**

--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideSecurityProvider.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideSecurityProvider.java
@@ -19,12 +19,12 @@
 package org.geoserver.security.iride;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import org.geoserver.config.util.XStreamPersister;
 import org.geoserver.security.GeoServerAuthenticationProvider;
 import org.geoserver.security.GeoServerRoleService;
 import org.geoserver.security.GeoServerSecurityProvider;
+import org.geoserver.security.GeoServerSecurityService;
 import org.geoserver.security.GeoServerUserGroupService;
 import org.geoserver.security.config.SecurityNamedServiceConfig;
 import org.geoserver.security.iride.config.IrideAuthenticationProviderConfig;
@@ -34,6 +34,7 @@ import org.geoserver.security.iride.util.factory.security.IrideAuthenticationPro
 import org.geoserver.security.iride.util.factory.security.IrideRoleServiceFactory;
 import org.geoserver.security.iride.util.factory.security.IrideUserGroupServiceFactory;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 
 import com.google.common.base.Preconditions;
 
@@ -53,7 +54,7 @@ public class IrideSecurityProvider extends GeoServerSecurityProvider {
     /**
      * <code>GeoServer</code> <code>IRIDE</code> <a href="http://docs.geoserver.org/stable/en/user/security/">security services</a> configurations logging message pattern.
      */
-    private static final String CONFIG_MESSAGE_PATTERN = "Configuring alias %s for %s instance";
+    private static final String CONFIG_MESSAGE_PATTERN = "Configuring alias {} for {} instance";
 
     /**
      * Factory that creates a new, configured, {@link IrideAuthenticationProviderFactory} instance.
@@ -90,9 +91,9 @@ public class IrideSecurityProvider extends GeoServerSecurityProvider {
      */
     @Override
     public void configure(XStreamPersister xp) {
-        LOGGER.config(String.format(CONFIG_MESSAGE_PATTERN, IrideAuthenticationProviderConfig.ALIAS, IrideAuthenticationProviderConfig.class.getSimpleName()));
-        LOGGER.config(String.format(CONFIG_MESSAGE_PATTERN, IrideRoleServiceConfig.ALIAS, IrideRoleServiceConfig.class.getSimpleName()));
-        LOGGER.config(String.format(CONFIG_MESSAGE_PATTERN, IrideUserGroupServiceConfig.ALIAS, IrideUserGroupServiceConfig.class.getSimpleName()));
+        LOGGER.debug(CONFIG_MESSAGE_PATTERN, IrideAuthenticationProviderConfig.ALIAS, IrideAuthenticationProviderConfig.class.getSimpleName());
+        LOGGER.debug(CONFIG_MESSAGE_PATTERN, IrideRoleServiceConfig.ALIAS, IrideRoleServiceConfig.class.getSimpleName());
+        LOGGER.debug(CONFIG_MESSAGE_PATTERN, IrideUserGroupServiceConfig.ALIAS, IrideUserGroupServiceConfig.class.getSimpleName());
 
         xp.getXStream().alias(IrideAuthenticationProviderConfig.ALIAS, IrideAuthenticationProviderConfig.class);
         xp.getXStream().alias(IrideRoleServiceConfig.ALIAS, IrideRoleServiceConfig.class);
@@ -111,6 +112,14 @@ public class IrideSecurityProvider extends GeoServerSecurityProvider {
     /*
      * (non-Javadoc)
      * @see org.geoserver.security.GeoServerSecurityProvider#createAuthenticationProvider(org.geoserver.security.config.SecurityNamedServiceConfig)
+     */
+    /**
+     * @throws IllegalStateException if any error occurs during {@link GeoServerSecurityService#initializeFromConfig(SecurityNamedServiceConfig)}
+     *                               execution.
+     *                               <p>{@link #createAuthenticationProvider(SecurityNamedServiceConfig)} is different in respect of the other two creational methods
+     *                               (namely {@link #createRoleService(SecurityNamedServiceConfig)} and {@link #createUserGroupService(SecurityNamedServiceConfig)}) because
+     *                               <em>it does not</em> declare to throw an {@link IOException} to signal that errors occured during initialization
+     *                               (interface design flaw maybe?)
      */
     @Override
     public GeoServerAuthenticationProvider createAuthenticationProvider(SecurityNamedServiceConfig config) {

--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideUserGroupService.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/IrideUserGroupService.java
@@ -21,8 +21,7 @@ package org.geoserver.security.iride;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
 
 import org.apache.commons.lang.StringUtils;
 import org.geoserver.security.GeoServerUserGroupService;
@@ -89,10 +88,7 @@ public class IrideUserGroupService extends AbstractUserGroupService implements G
      */
     @Override
     public void initializeFromConfig(SecurityNamedServiceConfig config) throws IOException {
-        LOGGER.log(Level.CONFIG,
-            "Initializing {0} with configuration object: \n\t {1}",
-            new Object[] { this.getClass().getSimpleName(), config }
-        );
+        LOGGER.debug("Initializing {} with configuration object: \n\t {}", this.getClass().getSimpleName(), config);
 
         this.name   = config.getName();
         this.config = new Config(config);
@@ -107,11 +103,11 @@ public class IrideUserGroupService extends AbstractUserGroupService implements G
      */
     @Override
     public GeoServerUser getUserByUsername(String username) throws IOException {
-        LOGGER.finer("Username: " + username);
+        LOGGER.trace("Username: {}", username);
 
         final IrideIdentity irideIdentity = IrideIdentity.parseIrideIdentity(username);
         if (irideIdentity == null) {
-            LOGGER.warning("Username: " + username + " is not a formally valid IRIDE digital identity");
+            LOGGER.warn("Username: {} is not a formally valid IRIDE digital identity", username);
 
             return null;
         }
@@ -135,7 +131,7 @@ public class IrideUserGroupService extends AbstractUserGroupService implements G
         user.setIrideIdentity(irideIdentity);
         user.setInfoPersonae(infoPersonae);
 
-        LOGGER.fine("Retrieved IRIDE User: " + user);
+        LOGGER.trace("Retrieved IRIDE User: {}", user);
 
         return user;
     }

--- a/security/sec-iride/src/main/java/org/geoserver/security/iride/authentication/IridePolicyAuthenticationProvider.java
+++ b/security/sec-iride/src/main/java/org/geoserver/security/iride/authentication/IridePolicyAuthenticationProvider.java
@@ -18,14 +18,13 @@
  */
 package org.geoserver.security.iride.authentication;
 
-import java.util.logging.Logger;
-
 import org.geoserver.security.iride.IrideGeoServerUser;
 import org.geoserver.security.iride.IrideUserGroupService;
 import org.geoserver.security.iride.entity.IrideIdentity;
 import org.geoserver.security.iride.service.IrideService;
 import org.geoserver.security.iride.service.IrideServiceAware;
 import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -118,7 +117,7 @@ public final class IridePolicyAuthenticationProvider extends AbstractUserDetails
             throw new AuthenticationServiceException("UserDetailsService returned null, which is an interface contract violation");
         }
 
-        LOGGER.fine("Loaded IRIDE User: " + loadedUser);
+        LOGGER.trace("Loaded IRIDE User: {}", loadedUser);
 
         return loadedUser;
     }
@@ -129,7 +128,7 @@ public final class IridePolicyAuthenticationProvider extends AbstractUserDetails
     @Override
     protected void additionalAuthenticationChecks(UserDetails userDetails, UsernamePasswordAuthenticationToken authentication) {
         if (authentication.getCredentials() == null) {
-            LOGGER.warning("Authentication failed: no credentials provided");
+            LOGGER.warn("Authentication failed: no credentials provided");
 
             throw new BadCredentialsException(this.messages.getMessage("AbstractUserDetailsAuthenticationProvider.badCredentials", "Bad credentials"));
         }
@@ -137,7 +136,7 @@ public final class IridePolicyAuthenticationProvider extends AbstractUserDetails
         if (! IrideGeoServerUser.class.isInstance(userDetails)) {
             final String msg = "Authentication succeded but wrong UserDetails type, expected IrideGeoServerUser but got " + userDetails == null ? "<NULL>" : userDetails.getClass().getSimpleName();
 
-            LOGGER.warning(msg);
+            LOGGER.warn(msg);
 
             throw new AuthenticationServiceException(msg);
         }
@@ -147,7 +146,7 @@ public final class IridePolicyAuthenticationProvider extends AbstractUserDetails
             ! irideGeoServerUser.hasInfoPersonae()) {
             final String msg = "Authentication succeded but wrong UserDetails type, expected IrideGeoServerUser with both an IrideIdentity and a Set<InfoPersona> properties defined";
 
-            LOGGER.warning(msg);
+            LOGGER.warn(msg);
 
             throw new AuthenticationServiceException(msg);
         }

--- a/security/sec-iride/src/test/java/org/geoserver/security/iride/AllTests.java
+++ b/security/sec-iride/src/test/java/org/geoserver/security/iride/AllTests.java
@@ -18,6 +18,7 @@
  */
 package org.geoserver.security.iride;
 
+import org.geoserver.security.iride.util.factory.roleservice.IrideRoleServiceFactoryTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -30,6 +31,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     IrideRoleServiceTest.class,
+    IrideRoleServiceFactoryTest.class,
     IrideUserGroupServiceTest.class,
 })
 public final class AllTests {

--- a/security/sec-iride/src/test/java/org/geoserver/security/iride/IrideRoleServiceTest.java
+++ b/security/sec-iride/src/test/java/org/geoserver/security/iride/IrideRoleServiceTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.SortedSet;
-import java.util.logging.Logger;
 
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -34,11 +33,12 @@ import org.geoserver.security.iride.config.IrideRoleServiceConfig;
 import org.geoserver.security.iride.util.factory.security.IrideAuthenticationProviderFactory;
 import org.geoserver.security.iride.util.factory.security.IrideRoleServiceFactory;
 import org.geoserver.security.iride.util.factory.security.IrideUserGroupServiceFactory;
-import org.geotools.util.logging.Logging;
+import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -60,7 +60,7 @@ public final class IrideRoleServiceTest {
     /**
      * Logger.
      */
-    private static final Logger LOGGER = Logging.getLogger(IrideRoleServiceTest.class);
+    private static final Logger LOGGER = LoggerProvider.getLogger(IrideRoleServiceTest.class);
 
     private static final String SAMPLE_USER_WITH_NO_ROLES = "AAAAAA00A11M000U/CSI PIEMONTE/DEMO 32/IPA/20161027103359/2/uQ4hHIMEEruA6DGThS3EuA==";
 
@@ -139,11 +139,11 @@ public final class IrideRoleServiceTest {
      */
     @Test
     public void testCannotCreateStore() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testCannotCreateStore");
+    	LOGGER.trace("BEGIN {}::testCannotCreateStore", this.getClass().getName());
 
         assertThat(false, is(this.createRoleService().canCreateStore()));
 
-        LOGGER.exiting(this.getClass().getName(), "testCannotCreateStore");
+        LOGGER.trace("END {}::testCannotCreateStore", this.getClass().getName());
     }
 
     /**
@@ -153,11 +153,11 @@ public final class IrideRoleServiceTest {
      */
     @Test
     public void testCreateStoreReturnsNull() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testCreateStoreReturnsNull");
+    	LOGGER.trace("BEGIN {}::testCreateStoreReturnsNull", this.getClass().getName());
 
         assertThat(this.createRoleService().createStore(), is(nullValue()));
 
-        LOGGER.exiting(this.getClass().getName(), "testCreateStoreReturnsNull");
+        LOGGER.trace("END {}::testCreateStoreReturnsNull", this.getClass().getName());
     }
 
     /**
@@ -167,14 +167,14 @@ public final class IrideRoleServiceTest {
      */
     @Test(expected = IllegalStateException.class)
     public void testGetRolesForSampleUserWithInvalidServerURL() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testGetRolesForSampleUserWithInvalidServerURL", new Object[] {SAMPLE_USER_WITH_NO_ROLES, this.config});
+        LOGGER.trace("BEGIN {}::testGetRolesForSampleUserWithInvalidServerURL", this.getClass().getName(), new Object[] { SAMPLE_USER_WITH_NO_ROLES, this.config });
 
         this.config.setServerURL(null);
 
         try {
             this.createRoleService().getRolesForUser(SAMPLE_USER_WITH_NO_ROLES);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testGetRolesForSampleUserWithInvalidServerURL");
+        	LOGGER.trace("END {}::testGetRolesForSampleUserWithInvalidServerURL", this.getClass().getName());
         }
     }
 
@@ -185,7 +185,7 @@ public final class IrideRoleServiceTest {
      */
     @Test
     public void testGetRolesForSampleUserWithNoRoles() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testGetRolesForSampleUserWithNoRoles", new Object[] {SAMPLE_USER_WITH_NO_ROLES, this.config});
+    	LOGGER.trace("BEGIN {}::testGetRolesForSampleUserWithNoRoles", this.getClass().getName(), new Object[] { SAMPLE_USER_WITH_NO_ROLES, this.config });
 
         try {
             final SortedSet<GeoServerRole> roles = this.createRoleService().getRolesForUser(SAMPLE_USER_WITH_NO_ROLES);
@@ -193,7 +193,7 @@ public final class IrideRoleServiceTest {
             assertThat(roles, not(nullValue()));
             assertThat(roles.size(), is(0));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testGetRolesForSampleUserWithNoRoles");
+        	LOGGER.trace("END {}::testGetRolesForSampleUserWithNoRoles", this.getClass().getName());
         }
     }
 
@@ -204,7 +204,7 @@ public final class IrideRoleServiceTest {
      */
     @Test(expected = UnsupportedOperationException.class)
     public void testGetRolesForSampleUserNotModifiable() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testGetRolesForSampleUserNotModifiable", new Object[] {SAMPLE_USER_WITH_NO_ROLES, this.config});
+    	LOGGER.trace("BEGIN {}::testGetRolesForSampleUserNotModifiable", this.getClass().getName(), new Object[] { SAMPLE_USER_WITH_NO_ROLES, this.config });
 
         try {
             final SortedSet<GeoServerRole> roles = this.createRoleService().getRolesForUser(SAMPLE_USER_WITH_NO_ROLES);
@@ -215,7 +215,7 @@ public final class IrideRoleServiceTest {
             // throws UnsupportedOperationException
             roles.add(DUMMY_ROLE);
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testGetRolesForSampleUserNotModifiable");
+        	LOGGER.trace("END {}::testGetRolesForSampleUserNotModifiable", this.getClass().getName());
         }
     }
 

--- a/security/sec-iride/src/test/java/org/geoserver/security/iride/IrideUserGroupServiceTest.java
+++ b/security/sec-iride/src/test/java/org/geoserver/security/iride/IrideUserGroupServiceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import org.geoserver.config.GeoServerDataDirectory;
 import org.geoserver.platform.GeoServerResourceLoader;
@@ -33,11 +32,12 @@ import org.geoserver.security.iride.config.IrideUserGroupServiceConfig;
 import org.geoserver.security.iride.util.factory.security.IrideAuthenticationProviderFactory;
 import org.geoserver.security.iride.util.factory.security.IrideRoleServiceFactory;
 import org.geoserver.security.iride.util.factory.security.IrideUserGroupServiceFactory;
-import org.geotools.util.logging.Logging;
+import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -59,7 +59,7 @@ public final class IrideUserGroupServiceTest {
     /**
      * Logger.
      */
-    private static final Logger LOGGER = Logging.getLogger(IrideRoleServiceTest.class);
+    private static final Logger LOGGER = LoggerProvider.getLogger(IrideRoleServiceTest.class);
 
     private static final String SAMPLE_USER_WITH_NO_ROLES = "AAAAAA00A11M000U/CSI PIEMONTE/DEMO 32/IPA/20161027103359/2/uQ4hHIMEEruA6DGThS3EuA==";
 
@@ -133,11 +133,11 @@ public final class IrideUserGroupServiceTest {
      */
     @Test
     public void testCannotCreateStore() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testCannotCreateStore");
+    	LOGGER.trace("BEGIN {}::testCannotCreateStore", this.getClass().getName());
 
         assertThat(false, is(this.createUserGroupService().canCreateStore()));
 
-        LOGGER.exiting(this.getClass().getName(), "testCannotCreateStore");
+        LOGGER.trace("END {}::testCannotCreateStore", this.getClass().getName());
     }
 
     /**
@@ -147,11 +147,11 @@ public final class IrideUserGroupServiceTest {
      */
     @Test
     public void testCreateStoreReturnsNull() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testCreateStoreReturnsNull");
+    	LOGGER.trace("BEGIN {}::testCreateStoreReturnsNull", this.getClass().getName());
 
         assertThat(this.createUserGroupService().createStore(), is(nullValue()));
 
-        LOGGER.exiting(this.getClass().getName(), "testCreateStoreReturnsNull");
+        LOGGER.trace("END {}::testCreateStoreReturnsNull", this.getClass().getName());
     }
 
     /**
@@ -161,7 +161,7 @@ public final class IrideUserGroupServiceTest {
      */
     @Test
     public void testCreateUserObjectSpecializedForIride() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testCreateUserObjectSpecializedForIride");
+        LOGGER.trace("BEGIN {}::testCreateUserObjectSpecializedForIride", this.getClass().getName());
 
         final String password = "xyz";
         final boolean isEnabled = true;
@@ -175,7 +175,7 @@ public final class IrideUserGroupServiceTest {
         assertThat(user.getPassword(), is(password));
         assertThat(user.isEnabled(), is(isEnabled));
 
-        LOGGER.exiting(this.getClass().getName(), "testCreateUserObjectSpecializedForIride");
+        LOGGER.trace("END {}::testGetUserByUsernameForSampleUserWithInvalidServerURL", this.getClass().getName());
     }
 
     /**
@@ -185,7 +185,7 @@ public final class IrideUserGroupServiceTest {
      */
     @Test(expected = IllegalStateException.class)
     public void testGetUserByUsernameForSampleUserWithInvalidServerURL() throws IOException {
-        LOGGER.entering(this.getClass().getName(), "testGetUserByUsernameForSampleUserWithInvalidServerURL", new Object[] {SAMPLE_USER_WITH_NO_ROLES, this.config});
+        LOGGER.trace("BEGIN {}::testGetUserByUsernameForSampleUserWithInvalidServerURL - {}", this.getClass().getName(), new Object[] { SAMPLE_USER_WITH_NO_ROLES, this.config });
 
         this.config.setServerURL(null);
 
@@ -194,7 +194,7 @@ public final class IrideUserGroupServiceTest {
 
             assertThat(user, is(nullValue()));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testGetUserByUsernameForSampleUserWithInvalidServerURL");
+        	LOGGER.trace("END {}::testGetUserByUsernameForSampleUserWithInvalidServerURL", this.getClass().getName());
         }
     }
 

--- a/security/sec-iride/src/test/java/org/geoserver/security/iride/util/factory/roleservice/IrideRoleServiceFactoryTest.java
+++ b/security/sec-iride/src/test/java/org/geoserver/security/iride/util/factory/roleservice/IrideRoleServiceFactoryTest.java
@@ -19,17 +19,16 @@
 package org.geoserver.security.iride.util.factory.roleservice;
 
 import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-
-import java.util.logging.Logger;
+import static org.junit.Assert.*;
 
 import org.geoserver.security.iride.IrideRoleService;
 import org.geoserver.security.iride.service.IrideService;
 import org.geoserver.security.iride.service.policy.IridePolicyManager;
 import org.geoserver.security.iride.util.factory.security.IrideRoleServiceFactory;
-import org.geotools.util.logging.Logging;
+import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -51,7 +50,7 @@ public final class IrideRoleServiceFactoryTest {
     /**
      * Logger.
      */
-    private static final Logger LOGGER = Logging.getLogger(IrideRoleServiceFactoryTest.class);
+    private static final Logger LOGGER = LoggerProvider.getLogger(IrideRoleServiceFactoryTest.class);
 
     /**
      * {@link IrideRoleService} Factory.
@@ -70,7 +69,8 @@ public final class IrideRoleServiceFactoryTest {
      */
     @Test
     public void testSetIrideRoleServiceFactoryPolicyEnforcer() {
-        LOGGER.entering(this.getClass().getName(), "testSetIrideRoleServiceFactoryPolicyEnforcer");
+    	LOGGER.trace("BEGIN {}::testSetIrideRoleServiceFactoryPolicyEnforcer", this.getClass().getName());
+
         try {
             assertThat(this.irideRoleServiceFactoryTest.getIrideService(), is(nullValue()));
 
@@ -78,7 +78,7 @@ public final class IrideRoleServiceFactoryTest {
 
             assertThat(this.irideRoleServiceFactoryTest.getIrideService(), is(not(nullValue())));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testSetIrideRoleServiceFactoryPolicyEnforcer");
+        	LOGGER.trace("END {}::testSetIrideRoleServiceFactoryPolicyEnforcer", this.getClass().getName());
         }
     }
 
@@ -87,7 +87,8 @@ public final class IrideRoleServiceFactoryTest {
      */
     @Test
     public void testIrideRoleServiceFactoryCreate() {
-        LOGGER.entering(this.getClass().getName(), "testIrideRoleServiceFactoryCreate");
+    	LOGGER.trace("BEGIN {}::testIrideRoleServiceFactoryCreate", this.getClass().getName());
+
         try {
             this.irideRoleServiceFactoryTest.setIrideService(this.irideService);
 
@@ -95,7 +96,7 @@ public final class IrideRoleServiceFactoryTest {
 
             assertThat(irideRoleService.getIrideService(), is(this.irideService));
         } finally {
-            LOGGER.exiting(this.getClass().getName(), "testIrideRoleServiceFactoryCreate");
+        	LOGGER.trace("END {}::testIrideRoleServiceFactoryCreate", this.getClass().getName());
         }
     }
 

--- a/security/sec-iride/src/test/resources/conf/logging.properties
+++ b/security/sec-iride/src/test/resources/conf/logging.properties
@@ -1,13 +1,19 @@
-handlers=java.util.logging.ConsoleHandler
+# Root logger option
+log4j.rootLogger=ALL, stdout
 
-# Default global logging level
-.level=ALL
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n
 
-# Package logging level
-org.geoserver.security.iride.util.validator.level=FINEST
+# === Specific levels === BEGIN ===
+log4j.category.org.geoserver.security.iride=ALL
 
-# Handlers
-java.util.logging.ConsoleHandler.level=ALL
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-# since Java 7 (https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html)
-java.util.logging.SimpleFormatter.format = %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s [%2$s] - %5$s %6$s%n
+log4j.category.it.geosolutions=DEBUG
+
+log4j.category.org.geotools=ERROR
+log4j.category.org.geoserver=ERROR
+
+log4j.category.org.springframework=ERROR
+# === Specific levels ===   END ===


### PR DESCRIPTION
  #254 

- logging mechanism reviewed to no longer rely on `org.geotools.util.logging.Logging` utility class, therefore removing the dependency to `GeoTools` from `iride-commons` module, letting that same module to be used outside `sec-iride` scope.
 - the logging mechanism is now satisfied by the introduction of [`SLF4J`](http://www.slf4j.org/) logging facade abstraction, with [`Log4J`](https://logging.apache.org/log4j/1.2/) as the logging framework used at _deploy time_