### PR TITLE
Iride roles retrieval for frontend component (issue #257)

### DIFF
--- a/frontend/iride-services/LICENSE.txt
+++ b/frontend/iride-services/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+    Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/frontend/iride-services/README.md
+++ b/frontend/iride-services/README.md
@@ -1,0 +1,7 @@
+IRIDE-SERVICES
+==========
+
+Description
+------------
+
+In the context of **csi-sira** project, **iride-services** defines a **REST** service to query for IRIDE roles using [CSI Piemonte](http://www.csipiemonte.it/) IRIDE Service.

--- a/frontend/iride-services/pom.xml
+++ b/frontend/iride-services/pom.xml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>it.geosolutions.csi.sira</groupId>
+		<artifactId>sira-root</artifactId>
+		<version>1.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>iride-services</artifactId>
+	<packaging>jar</packaging>
+
+	<name>CSI SIRA - IRIDE REST Services</name>
+    <description>REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service</description>
+
+	<url>https://github.com/geosolutions-it/csi-sira/tree/master/frontend/iride-services</url>
+    <inceptionYear>2016</inceptionYear>
+
+    <organization>
+        <name>CSI-Piemonte</name>
+        <url>http://www.csipiemonte.it</url>
+    </organization>
+
+    <developers>
+        <developer>
+          <id>seancrow76</id>
+          <name>Simone Cornacchia</name>
+          <email>simone.cornacchia AT assioma.net</email>
+          <organization>Assioma.net</organization>
+          <organizationUrl>http://www.assioma.net</organizationUrl>
+          <roles>
+            <role>architect</role>
+            <role>developer</role>
+          </roles>
+          <timezone>+1</timezone>
+          <properties>
+            <skype>seancrow76</skype>
+          </properties>
+          <url>https://github.com/seancrow</url>
+        </developer>
+    </developers>
+
+    <contributors>
+        <contributor>
+          <name>Diego Sanmartino</name>
+          <email>diego.sanmartino AT csi.it</email>
+          <organization>CSI-Piemonte</organization>
+          <organizationUrl>http://www.csipiemonte.it</organizationUrl>
+          <roles>
+            <role>architect</role>
+          </roles>
+          <timezone>+1</timezone>
+        </contributor>
+    </contributors>
+
+	<properties>
+        <!-- Java Version -->
+        <java.version>1.7</java.version>
+
+        <!-- Dependencies -->
+        <spring.version>3.1.4.RELEASE</spring.version>
+        <spring-security.version>3.1.0.RELEASE</spring-security.version>
+
+        <!-- Build -->
+        <maven.build.timestamp.format>dd-MMM-yyyy HH:mm</maven.build.timestamp.format>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+	</properties>
+
+    <repositories>
+        <!-- https://maven-repository.com/artifact/org.springframework/spring-test-mvc/1.0.0.M2 -->
+		<repository>
+			<id>spring-milestones</id>
+			<url>http://repo.spring.io/libs-milestone/</url>
+		</repository>
+    </repositories>
+
+	<dependencies>
+        <!-- SIRA modules -->
+        <dependency>
+            <groupId>org.geoserver.security</groupId>
+            <artifactId>iride-commons</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+		    <groupId>org.geoserver.security</groupId>
+		    <artifactId>iride-entities</artifactId>
+		    <version>1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+		    <groupId>org.geoserver.security</groupId>
+		    <artifactId>iride-service-client</artifactId>
+		    <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-mapper-asl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+        <!-- Test Dependencies (see https://tedvinke.wordpress.com/2013/12/17/mixing-junit-hamcrest-and-mockito-explaining-nosuchmethoderror/) -->
+
+        <!-- Mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hamcrest-core</artifactId>
+                    <groupId>org.hamcrest</groupId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>hamcrest-core</artifactId>
+                    <groupId>org.hamcrest</groupId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Hamcrest -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JSON Path -->
+		<dependency>
+		    <groupId>com.jayway.jsonpath</groupId>
+		    <artifactId>json-path</artifactId>
+		    <version>0.8.1</version>
+		    <scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>com.jayway.jsonpath</groupId>
+		    <artifactId>json-path-assert</artifactId>
+		    <version>0.8.1</version>
+		    <scope>test</scope>
+		</dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+		<dependency>
+		    <groupId>org.springframework</groupId>
+		    <artifactId>spring-test-mvc</artifactId>
+		    <version>1.0.0.M2</version>
+		    <scope>test</scope>
+		</dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>${spring-security.version}</version>
+        </dependency>
+	</dependencies>
+
+    <build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+
+        <plugins>
+            <!-- compilation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <!--debug>true</debug-->
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <!-- versioning -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.2.2</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+
+            <!-- resources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <!-- sources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <attach>true</attach>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- eclipse ide integration -->
+            <plugin>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <downloadSources>false</downloadSources>
+                    <additionalProjectnatures>
+                        <projectnature>org.springframework.ide.eclipse.core.springnature</projectnature>
+                    </additionalProjectnatures>
+                </configuration>
+            </plugin>
+
+            <!-- initialize git revision info -->
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- https://github.com/ktoso/maven-git-commit-id-plugin -->
+                <configuration>
+                    <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+                    <prefix>build</prefix>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <skipPoms>false</skipPoms>
+                    <verbose>false</verbose>
+                </configuration>
+            </plugin>
+
+            <!-- packaging -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Application-Name>${project.artifactId}-${project.version}</Application-Name>
+                            <Project-Version>${project.version}</Project-Version>
+                            <Build-Timestamp>${maven.build.timestamp}</Build-Timestamp>
+                            <Git-Revision>${build.commit.id}</Git-Revision>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <!-- javadoc -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <configuration>
+                    <show>public</show>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/frontend/iride-services/pom.xml
+++ b/frontend/iride-services/pom.xml
@@ -206,6 +206,7 @@
 		    <version>1.0.0.M2</version>
 		    <scope>test</scope>
 		</dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-expression</artifactId>
             <version>${spring.version}</version>
@@ -213,17 +214,14 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>${spring-security.version}</version>
         </dependency>
 	</dependencies>
 

--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/Constants.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/Constants.java
@@ -1,0 +1,61 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package it.csi.sira.frontend.iride.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+final class Constants {
+
+    /**
+     * Application name requesting <code>IRIDE</code> service.
+     */
+    static final String APPLICATION_NAME = "DECSIRA";
+
+    /**
+     * {@link RequestMapping} for {@link IrideServiceController} type.
+     */
+    static final String MAPPING_IRIDE_SERVICE = "/iride";
+
+    /**
+     * {@link RequestMapping} for {@link IrideServiceController#getRolesForDigitalIdentity(String)} method.
+     */
+    static final String MAPPING_ROLES_FOR_DIGITAL_IDENTITY = "/getRolesForDigitalIdentity";
+
+    /**
+     * <a href="https://shibboleth.net/">Shibboleth</a> <code>IRIDE</code> <code>HTTP</code> request header attribute.
+     */
+    static final String HEADER_SHIBBOLETH_IRIDE = "Shib-Iride-IdentitaDigitale";
+
+    /**
+     * <a href="https://www.w3.org/Protocols/HTTP/HTRQ_Headers.html#z3">Accept</a> <code>HTTP</code> request header attribute.
+     */
+    static final String HEADER_ACCEPT_JSON = "Accept=application/json";
+
+    /**
+     * Constructor.
+     */
+    private Constants() {
+        /* NOP */
+    }
+
+}

--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceConstants.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceConstants.java
@@ -18,43 +18,44 @@
  */
 package it.csi.sira.frontend.iride.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  *
  * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
  */
-final class Constants {
+public final class IrideServiceConstants {
 
     /**
      * Application name requesting <code>IRIDE</code> service.
      */
-    static final String APPLICATION_NAME = "DECSIRA";
+    public static final String APPLICATION_NAME = "DECSIRA";
 
     /**
      * {@link RequestMapping} for {@link IrideServiceController} type.
      */
-    static final String MAPPING_IRIDE_SERVICE = "/iride";
+    public static final String MAPPING_IRIDE_SERVICE = "/iride";
 
     /**
      * {@link RequestMapping} for {@link IrideServiceController#getRolesForDigitalIdentity(String)} method.
      */
-    static final String MAPPING_ROLES_FOR_DIGITAL_IDENTITY = "/getRolesForDigitalIdentity";
+    public static final String MAPPING_ROLES_FOR_DIGITAL_IDENTITY = "/getRolesForDigitalIdentity";
 
     /**
      * <a href="https://shibboleth.net/">Shibboleth</a> <code>IRIDE</code> <code>HTTP</code> request header attribute.
      */
-    static final String HEADER_SHIBBOLETH_IRIDE = "Shib-Iride-IdentitaDigitale";
+    public static final String HEADER_SHIBBOLETH_IRIDE = "Shib-Iride-IdentitaDigitale";
 
     /**
      * <a href="https://www.w3.org/Protocols/HTTP/HTRQ_Headers.html#z3">Accept</a> <code>HTTP</code> request header attribute.
      */
-    static final String HEADER_ACCEPT_JSON = "Accept=application/json";
+    public static final String HEADER_ACCEPT_JSON = "Accept=" + MediaType.APPLICATION_JSON_VALUE;
 
     /**
      * Constructor.
      */
-    private Constants() {
+    private IrideServiceConstants() {
         /* NOP */
     }
 

--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceController.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceController.java
@@ -1,0 +1,146 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package it.csi.sira.frontend.iride.controller;
+
+import java.io.IOException;
+
+import org.geoserver.security.iride.entity.IrideApplication;
+import org.geoserver.security.iride.entity.IrideIdentity;
+import org.geoserver.security.iride.entity.IrideRole;
+import org.geoserver.security.iride.service.IrideService;
+import org.geoserver.security.iride.util.logging.LoggerProvider;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * <code>IRIDE</code> <code>REST</code> action, backed by <a href="http://www.csipiemonte.it/">CSI</a> <code>IRIDE</code> service.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+@Controller
+@RequestMapping(method = RequestMethod.GET, value = Constants.MAPPING_IRIDE_SERVICE)
+public class IrideServiceController {
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerProvider.getLogger(IrideServiceController.class);
+
+    /**
+     * "No roles" empty {@link IrideRole} array.
+     */
+    private static final IrideRole[] NO_ROLES = new IrideRole[0];
+
+    /**
+     * <code>IRIDE</code> service "policies" enforcer instance.
+     */
+    private IrideService irideService;
+
+    /**
+     * @return the irideService
+     */
+    public IrideService getIrideService() {
+        return this.irideService;
+    }
+
+    /**
+     * @param irideService the irideService to set
+     */
+    public void setIrideService(IrideService irideService) {
+        this.irideService = irideService;
+    }
+
+    /**
+     *
+     * @param user
+     * @return
+     */
+    @RequestMapping(
+    	headers = {
+    		Constants.HEADER_ACCEPT_JSON,
+    		Constants.HEADER_SHIBBOLETH_IRIDE,
+    	},
+    	value = Constants.MAPPING_ROLES_FOR_DIGITAL_IDENTITY
+    )
+    @ResponseBody
+    public ResponseEntity<String> getRolesForDigitalIdentity(
+    	@RequestHeader(
+    		value = Constants.HEADER_SHIBBOLETH_IRIDE,
+    		defaultValue = ""
+    	) String user) {
+        LOGGER.trace("IRIDE Digital Identity: {}", user);
+
+        try {
+            final IrideRole[] roles = this.getRolesForUser(user);
+
+            LOGGER.trace("Got {} roles for IRIDE Digital Identity {}", roles.length, user);
+
+            return new ResponseEntity<>(this.toJson(roles), HttpStatus.OK);
+        } catch (IOException e) {
+            LOGGER.error("IRIDE roles retrieval for Digital Identity {} error: {}", user, e.getMessage(), e);
+
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     *
+     * @param user
+     * @return
+     */
+    private IrideRole[] getRolesForUser(String user) {
+        IrideRole[] roles = NO_ROLES;
+
+        final IrideIdentity irideIdentity = IrideIdentity.parseIrideIdentity(user);
+        if (irideIdentity != null) {
+            roles = this.getIrideService().findRuoliForPersonaInApplication(
+                irideIdentity,
+                new IrideApplication(Constants.APPLICATION_NAME)
+            );
+        }
+
+        return roles;
+    }
+
+    /**
+     *
+     * @param roles
+     * @return
+     * @throws JsonProcessingException
+     */
+    private String toJson(IrideRole[] roles) throws JsonProcessingException {
+        final ObjectMapper mapper = new ObjectMapper();
+
+        final String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(roles);
+
+        LOGGER.trace("IRIDE roles to JSON: {}", json);
+
+        return json;
+    }
+
+}

--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/vo/IrideRoleVO.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/vo/IrideRoleVO.java
@@ -1,0 +1,83 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package it.csi.sira.frontend.iride.vo;
+
+import org.geoserver.security.iride.entity.IrideRole;
+
+/**
+ * <code>IRIDE</code> Role <a href="https://en.wikipedia.org/wiki/Value_object#Value_Objects_in_Java">value object</a>.
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public final class IrideRoleVO {
+
+    /**
+     * <code>IRIDE</code> Role code.
+     */
+    private final String code;
+
+    /**
+     * <code>IRIDE</code> Role domain code.
+     */
+    private final String domain;
+
+    /**
+     * <code>IRIDE</code> Role mnemonic string representation.
+     */
+    private final String mnemonic;
+
+    /**
+     * Constructor.
+     *
+     * @param role <code>IRIDE</code> Role entity.
+     */
+    public IrideRoleVO(IrideRole role) {
+        this.code     = role.getCode();
+        this.domain   = role.getDomain();
+        this.mnemonic = role.toMnemonicRepresentation();
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role code.
+     *
+     * @return the <code>IRIDE</code> Role code
+     */
+    public String getCode() {
+        return this.code;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role domain code.
+     *
+     * @return the <code>IRIDE</code> Role domain code
+     */
+    public String getDomain() {
+        return this.domain;
+    }
+
+    /**
+     * Returns the <code>IRIDE</code> Role mnemonic string representation.
+     *
+     * @return the <code>IRIDE</code> Role mnemonic string representation
+     */
+    public String getMnemonic() {
+        return this.mnemonic;
+    }
+
+}

--- a/frontend/iride-services/src/main/resources/applicationContext.xml
+++ b/frontend/iride-services/src/main/resources/applicationContext.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+
+    <mvc:annotation-driven />
+
+    <context:component-scan base-package="it.csi.sira.frontend.iride.controller" />
+
+</beans>

--- a/frontend/iride-services/src/main/resources/applicationContext.xml
+++ b/frontend/iride-services/src/main/resources/applicationContext.xml
@@ -4,10 +4,12 @@
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
                            http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
     <mvc:annotation-driven />
 
+    <context:annotation-config />
     <context:component-scan base-package="it.csi.sira.frontend.iride.controller" />
 
 </beans>

--- a/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
+++ b/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
@@ -18,17 +18,30 @@
  */
 package test.it.csi.sira.frontend.iride.controller;
 
-import static org.junit.Assert.fail;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.server.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.server.result.MockMvcResultMatchers.*;
+import it.csi.sira.frontend.iride.controller.IrideServiceConstants;
 
+import org.geoserver.security.iride.entity.IrideApplication;
+import org.geoserver.security.iride.entity.IrideIdentity;
+import org.geoserver.security.iride.entity.IrideRole;
 import org.geoserver.security.iride.service.IrideService;
+import org.geoserver.security.iride.util.logging.LoggerProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.web.server.MockMvc;
+import org.springframework.test.web.server.MvcResult;
 import org.springframework.test.web.server.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -37,33 +50,143 @@ import org.springframework.web.context.WebApplicationContext;
  * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration({ "classpath:testContext.xml", "classpath:applicationContext.xml" })
+@ContextConfiguration(
+    loader = IrideServiceControllerTestContextLoader.class,
+    locations = { "classpath:testContext.xml", "classpath:applicationContext.xml" }
+)
 public final class IrideServiceControllerTest {
 
-	private MockMvc mockMvc;
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LoggerProvider.getLogger(IrideServiceControllerTest.class);
 
-	@Autowired
-	private IrideService irideServiceMock;
+    private MockMvc mockMvc;
+
+    @Autowired
+    private IrideService irideServiceMock;
 
     @Autowired
     private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private IrideIdentity irideIdentity;
+
+    @Autowired
+    private IrideApplication application;
+
+    @Autowired
+    private IrideRole role;
 
     /**
      * @throws java.lang.Exception
      */
     @Before
     public void setUp() throws Exception {
-    	Mockito.reset(this.irideServiceMock);
+        Mockito.reset(this.irideServiceMock);
 
-    	this.mockMvc = MockMvcBuilders.webApplicationContextSetup(this.webApplicationContext).build();
+        this.mockMvc = MockMvcBuilders.webApplicationContextSetup(this.webApplicationContext).build();
     }
 
     /**
      * Test method for {@link it.csi.sira.frontend.iride.controller.IrideServiceController#getRolesForDigitalIdentity(java.lang.String)}.
+     *
+     * @throws Exception
      */
     @Test
-    public void testGetRolesForDigitalIdentity() {
-        fail("Not yet implemented");
+    public void testGetRolesForValidDigitalIdentity() throws Exception {
+        when(this.irideServiceMock.findRuoliForPersonaInApplication(this.irideIdentity, this.application)).then(new Answer<IrideRole[]>() {
+
+            /*
+             * (non-Javadoc)
+             * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
+             */
+            @Override
+            public IrideRole[] answer(InvocationOnMock invocation) throws Throwable {
+                return new IrideRole[] {
+                    IrideServiceControllerTest.this.role
+                };
+            }
+        });
+
+        final String url = IrideServiceConstants.MAPPING_IRIDE_SERVICE + IrideServiceConstants.MAPPING_ROLES_FOR_DIGITAL_IDENTITY;
+
+        LOGGER.trace("BEGIN {}::testGetRolesForValidDigitalIdentity", this.getClass().getName());
+        try {
+            final MvcResult mvcResult = this.mockMvc.perform(
+                get(url)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE, this.irideIdentity.toString())
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].code", is("PA_GEN_DECSIRA")))
+            .andExpect(jsonPath("$[0].domain", is("REG_PMN")))
+            .andExpect(jsonPath("$[0].mnemonic", is("PA_GEN_DECSIRA@REG_PMN")))
+            .andReturn();
+
+            verify(this.irideServiceMock, times(1)).findRuoliForPersonaInApplication(this.irideIdentity, this.application);
+            verifyNoMoreInteractions(this.irideServiceMock);
+
+            LOGGER.debug("{} result (HTTP {}): {}", url, mvcResult.getResponse().getStatus(), mvcResult.getResponse().getContentAsString());
+        } finally {
+            LOGGER.trace("END {}::testGetRolesForValidDigitalIdentity", this.getClass().getName());
+        }
+    }
+
+    /**
+     * Test method for {@link it.csi.sira.frontend.iride.controller.IrideServiceController#getRolesForDigitalIdentity(java.lang.String)}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetRolesWithInvalidDigitalIdentityHeader() throws Exception {
+        final String url = IrideServiceConstants.MAPPING_IRIDE_SERVICE + IrideServiceConstants.MAPPING_ROLES_FOR_DIGITAL_IDENTITY;
+
+        LOGGER.trace("BEGIN {}::testGetRolesWithInvalidDigitalIdentityHeader", this.getClass().getName());
+        try {
+            final MvcResult mvcResult = this.mockMvc.perform(
+                get(url)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE, "INVALID_DIGITAL_IDENTITY")
+            )
+            .andExpect(status().isOk())
+            .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", hasSize(0)))
+            .andReturn();
+
+            verifyNoMoreInteractions(this.irideServiceMock);
+
+            LOGGER.debug("{} result (HTTP {}): {}", url, mvcResult.getResponse().getStatus(), mvcResult.getResponse().getContentAsString());
+        } finally {
+            LOGGER.trace("END {}::testGetRolesWithInvalidDigitalIdentityHeader", this.getClass().getName());
+        }
+    }
+
+    /**
+     * Test method for {@link it.csi.sira.frontend.iride.controller.IrideServiceController#getRolesForDigitalIdentity(java.lang.String)}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetRolesWithoutDigitalIdentityHeader() throws Exception {
+        final String url = IrideServiceConstants.MAPPING_IRIDE_SERVICE + IrideServiceConstants.MAPPING_ROLES_FOR_DIGITAL_IDENTITY;
+
+        LOGGER.trace("BEGIN {}::testGetRolesWithoutDigitalIdentityHeader", this.getClass().getName());
+        try {
+            final MvcResult mvcResult = this.mockMvc.perform(
+                get(url).accept(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+            verifyNoMoreInteractions(this.irideServiceMock);
+
+            LOGGER.debug("{} result (HTTP {}): {}", url, mvcResult.getResponse().getStatus(), mvcResult.getResponse().getContentAsString());
+        } finally {
+            LOGGER.trace("END {}::testGetRolesWithoutDigitalIdentityHeader", this.getClass().getName());
+        }
     }
 
 }

--- a/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
+++ b/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
@@ -1,0 +1,69 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package test.it.csi.sira.frontend.iride.controller;
+
+import static org.junit.Assert.fail;
+
+import org.geoserver.security.iride.service.IrideService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.server.MockMvc;
+import org.springframework.test.web.server.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({ "classpath:testContext.xml", "classpath:applicationContext.xml" })
+public final class IrideServiceControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private IrideService irideServiceMock;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+    	Mockito.reset(this.irideServiceMock);
+
+    	this.mockMvc = MockMvcBuilders.webApplicationContextSetup(this.webApplicationContext).build();
+    }
+
+    /**
+     * Test method for {@link it.csi.sira.frontend.iride.controller.IrideServiceController#getRolesForDigitalIdentity(java.lang.String)}.
+     */
+    @Test
+    public void testGetRolesForDigitalIdentity() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTestContextLoader.java
+++ b/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTestContextLoader.java
@@ -1,0 +1,36 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package test.it.csi.sira.frontend.iride.controller;
+
+import test.org.springframework.test.context.support.MockWebContextLoader;
+
+/**
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+final class IrideServiceControllerTestContextLoader extends MockWebContextLoader {
+
+    /**
+     * Constructor.
+     */
+    IrideServiceControllerTestContextLoader() {
+        super("src/test/resources");
+    }
+
+}

--- a/frontend/iride-services/src/test/java/test/org/springframework/test/context/support/MockWebContextLoader.java
+++ b/frontend/iride-services/src/test/java/test/org/springframework/test/context/support/MockWebContextLoader.java
@@ -1,0 +1,153 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package test.org.springframework.test.context.support;
+
+import javax.servlet.RequestDispatcher;
+
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotatedBeanDefinitionReader;
+import org.springframework.context.annotation.AnnotationConfigUtils;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.FileSystemResourceLoader;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.mock.web.MockRequestDispatcher;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.support.AbstractContextLoader;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+
+/**
+ *
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ */
+public class MockWebContextLoader extends AbstractContextLoader {
+
+    /**
+     * Mocked servlet context.
+     */
+    private final MockServletContext servletContext;
+
+    /**
+     * Constructor.
+     *
+     * @param warRootDir
+     */
+    public MockWebContextLoader(String warRootDir) {
+        this(warRootDir, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param warRootDir
+     * @param isClasspathRelative
+     */
+    public MockWebContextLoader(String warRootDir, boolean isClasspathRelative) {
+        final ResourceLoader resourceLoader = isClasspathRelative ? new DefaultResourceLoader() : new FileSystemResourceLoader();
+
+        this.servletContext = this.initServletContext(warRootDir, resourceLoader);
+    }
+
+    /* (non-Javadoc)
+     * @see org.springframework.test.context.SmartContextLoader#loadContext(org.springframework.test.context.MergedContextConfiguration)
+     */
+    @Override
+    public ApplicationContext loadContext(MergedContextConfiguration mergedConfig) throws Exception {
+        final GenericWebApplicationContext context = new GenericWebApplicationContext();
+        context.getEnvironment().setActiveProfiles(mergedConfig.getActiveProfiles());
+
+        this.prepareContext(context);
+        this.loadBeanDefinitions(context, mergedConfig);
+
+        return context;
+    }
+
+    /* (non-Javadoc)
+     * @see org.springframework.test.context.ContextLoader#loadContext(java.lang.String[])
+     */
+    @Override
+    public ApplicationContext loadContext(String... locations) throws Exception {
+        final GenericWebApplicationContext context = new GenericWebApplicationContext();
+
+        this.prepareContext(context);
+        this.loadBeanDefinitions(context, locations);
+
+        return context;
+    }
+
+    /* (non-Javadoc)
+     * @see org.springframework.test.context.support.AbstractContextLoader#getResourceSuffix()
+     */
+    @Override
+    protected String getResourceSuffix() {
+        return "-context.xml";
+    }
+
+    /**
+     *
+     * @param warRootDir
+     * @param resourceLoader
+     * @return
+     */
+    private MockServletContext initServletContext(String warRootDir, ResourceLoader resourceLoader) {
+        return new MockServletContext(warRootDir, resourceLoader) {
+            // Required for DefaultServletHttpRequestHandler...
+            public RequestDispatcher getNamedDispatcher(String path) {
+                return (path.equals("default")) ? new MockRequestDispatcher(path) : super.getNamedDispatcher(path);
+            }
+        };
+    }
+
+    /**
+     *
+     * @param context
+     */
+    private void prepareContext(GenericWebApplicationContext context) {
+        this.servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
+
+        context.setServletContext(this.servletContext);
+    }
+
+    /**
+    *
+    * @param context
+    * @param mergedConfig
+    */
+   private void loadBeanDefinitions(GenericWebApplicationContext context, MergedContextConfiguration mergedConfig) {
+       new AnnotatedBeanDefinitionReader(context).register(mergedConfig.getClasses());
+
+       this.loadBeanDefinitions(context, mergedConfig.getLocations());
+   }
+
+    /**
+     *
+     * @param context
+     * @param locations
+     */
+    private void loadBeanDefinitions(GenericWebApplicationContext context, String[] locations) {
+        new XmlBeanDefinitionReader(context).loadBeanDefinitions(locations);
+        AnnotationConfigUtils.registerAnnotationConfigProcessors(context);
+
+        context.refresh();
+        context.registerShutdownHook();
+    }
+
+}

--- a/frontend/iride-services/src/test/java/test/org/springframework/test/context/support/package-info.java
+++ b/frontend/iride-services/src/test/java/test/org/springframework/test/context/support/package-info.java
@@ -1,0 +1,31 @@
+/*
+ *  REST service to query for IRIDE roles using CSI-Piemonte IRIDE Service.
+ *  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+/**
+ * @author "Simone Cornacchia - seancrow76@gmail.com, simone.cornacchia@consulenti.csi.it (CSI:71740)"
+ *
+ * Please see also, in order of importance, the following links for a deep tour about the topic of testing (and mocking) <a href="http://docs.spring.io/spring/docs/3.1.4.RELEASE/spring-framework-reference/html/mvc.html">Spring MVC</a>, with with Spring 3.1.x version:
+ * <ul>
+ *   <li><a href="http://stackoverflow.com/questions/35588023/mocking-autowiring-beans-with-spring-3-1-x-and-mockmvc">Mocking/autowiring beans with Spring 3.1.x and MockMvc</a></li>
+ *   <li><a href="https://stevelibonati.wordpress.com/tag/spring-mvc-test/">Spring-Mvc-Test With A Sprinkle Of Mockito</a></li>
+ *   <li><a href="https://github.com/spring-projects/spring-test-mvc">spring-projects/spring-test-mvc</a></li>
+ *   <li><a href="https://www.petrikainulainen.net/programming/spring-framework/unit-testing-of-spring-mvc-controllers-configuration">Unit Testing of Spring MVC Controllers: Configuration</a></li>
+ *   <li><a href="https://www.petrikainulainen.net/programming/spring-framework/unit-testing-of-spring-mvc-controllers-rest-api/">Unit Testing of Spring MVC Controllers: REST API</a></li>
+ * </ul>
+ */
+package test.org.springframework.test.context.support;

--- a/frontend/iride-services/src/test/resources/log4j.properties
+++ b/frontend/iride-services/src/test/resources/log4j.properties
@@ -1,0 +1,17 @@
+# Root logger option
+log4j.rootLogger=ALL, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n
+
+# === Specific levels === BEGIN ===
+log4j.category.it.geosolutions=DEBUG
+
+log4j.category.org.springframework=ERROR
+
+log4j.category.test=ERROR
+log4j.category.test.it.csi.sira.frontend.iride.controller=TRACE
+# === Specific levels ===   END ===

--- a/frontend/iride-services/src/test/resources/testContext.xml
+++ b/frontend/iride-services/src/test/resources/testContext.xml
@@ -7,14 +7,29 @@
                            http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
                            http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
-    <mvc:annotation-driven />
-
-    <context:component-scan base-package="it.csi.sira.frontend.iride.controller" />
-
-    <bean id="irideService"
-          class="org.mockito.Mockito"
-          factory-method="mock">
+    <bean id="irideService" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.geoserver.security.iride.service.IrideService" />
     </bean>
+
+    <!-- IRIDE Entities === BEGIN === -->
+
+    <bean id="application"
+          class="org.geoserver.security.iride.entity.IrideApplication">
+        <constructor-arg type="java.lang.String" value="DECSIRA" />
+    </bean>
+
+    <bean id="irideIdentity"
+          class="org.geoserver.security.iride.entity.IrideIdentity"
+          factory-method="parseIrideIdentity">
+        <constructor-arg type="java.lang.String" value="AAAAAA00B77B000F/CSI PIEMONTE/DEMO 20/IPA/20160531113948/2/1IQssTaf4vNMa66qU52m7g==" />
+    </bean>
+
+    <bean id="role"
+          class="org.geoserver.security.iride.entity.IrideRole"
+          factory-method="parseRole">
+        <constructor-arg type="java.lang.String" value="PA_GEN_DECSIRA@REG_PMN" />
+    </bean>
+
+    <!-- IRIDE Entities ===   END === -->
 
 </beans>

--- a/frontend/iride-services/src/test/resources/testContext.xml
+++ b/frontend/iride-services/src/test/resources/testContext.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+                           http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+
+    <mvc:annotation-driven />
+
+    <context:component-scan base-package="it.csi.sira.frontend.iride.controller" />
+
+    <bean id="irideService"
+          class="org.mockito.Mockito"
+          factory-method="mock">
+        <constructor-arg value="org.geoserver.security.iride.service.IrideService" />
+    </bean>
+
+</beans>

--- a/frontend/web/pom.xml
+++ b/frontend/web/pom.xml
@@ -32,6 +32,11 @@
 			<artifactId>metadata-services</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>it.geosolutions.csi.sira</groupId>
+			<artifactId>iride-services</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		<!-- ================================================================ -->
 		<!-- GeoStore modules -->
 		<!-- ================================================================ -->


### PR DESCRIPTION
#257 

- `IRIDE` roles retrieval for Frontend component by using `IRIDE` service client
 - a simple _Spring MVC REST_ action has been defined, relying on `IRIDE` service client to query the `IRIDE` service
 - the action "answers" only when called by a `GET` method, with `IRIDE` _Digital Identity_ header defined
 - with unit tests (and mocks)