### PR TITLE
Fix sira-root Maven modules list (issue #279)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
         <module>frontend/web</module>
         <module>backend</module>
         <module>security</module>
+        <module>frontend/iride-services</module>        
         <module>frontend/metadata-services</module>        
         <module>metadata-batch</module>        
     </modules>


### PR DESCRIPTION
#279 

added the missing reference to `iride-services` module
