### PR TITLE
Added license headers to non-Java files (#issue 271)

### DIFF
--- a/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/IrideServiceImpl.java
+++ b/security/iride-service-client/src/main/java/org/geoserver/security/iride/service/IrideServiceImpl.java
@@ -86,7 +86,7 @@ public final class IrideServiceImpl implements IrideService {
     /**
      * Policy execution error message format.
      */
-    private static final String ERROR_MESSAGE_FORMAT = "%s error: %s";
+    private static final String ERROR_MESSAGE_FORMAT = "{} error: {}";
 
     /**
      * <code>IRIDE</code> server <code>URL</code>.

--- a/security/iride-service-client/src/main/resources/iride/soap/request/findRuoliForPersonaInApplication.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/findRuoliForPersonaInApplication.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/findRuoliForPersonaInUseCase.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/findRuoliForPersonaInUseCase.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/findUseCasesForPersonaInApplication.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/findUseCasesForPersonaInApplication.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/getInfoPersonaInUseCase.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/getInfoPersonaInUseCase.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/identificaUserPassword.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/identificaUserPassword.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/isIdentitaAutentica.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/isIdentitaAutentica.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/isPersonaAutorizzataInUseCase.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/isPersonaAutorizzataInUseCase.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/request/isPersonaInRuolo.ftl
+++ b/security/iride-service-client/src/main/resources/iride/soap/request/isPersonaInRuolo.ftl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<#--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <soapenv:Envelope
     xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
     xmlns:pep="http://pep.base.nmsf.csi.it/"

--- a/security/iride-service-client/src/main/resources/iride/soap/response/findRuoliForPersonaInApplication.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/findRuoliForPersonaInApplication.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/findRuoliForPersonaInUseCase.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/findRuoliForPersonaInUseCase.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/findUseCasesForPersonaInApplication.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/findUseCasesForPersonaInApplication.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/getInfoPersonaInUseCase.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/getInfoPersonaInUseCase.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="text" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/getInfoPersonaInUseCaseReturn.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/getInfoPersonaInUseCaseReturn.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/identificaUserPassword.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/identificaUserPassword.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/isIdentitaAutentica.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/isIdentitaAutentica.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/isPersonaAutorizzataInUseCase.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/isPersonaAutorizzataInUseCase.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="no" />

--- a/security/iride-service-client/src/main/resources/iride/soap/response/isPersonaInRuolo.xsl
+++ b/security/iride-service-client/src/main/resources/iride/soap/response/isPersonaInRuolo.xsl
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Simple SOAP service client for doing authentication and authorization operations using CSI-Piemonte IRIDE Service.
+  Copyright (C) 2016  Regione Piemonte (www.regione.piemonte.it)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, write to the Free Software Foundation, Inc.,
+  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes" />


### PR DESCRIPTION
#271 

Added license headers to non-Java files, such as XSL documents or FreeMarker Template files (.ftl)
