### PR TITLE
HTTP header in REST service (issue #306)

### DIFF
--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceConstants.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceConstants.java
@@ -18,7 +18,6 @@
  */
 package it.csi.sira.frontend.iride.controller;
 
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
@@ -47,11 +46,6 @@ public final class IrideServiceConstants {
      * <a href="https://shibboleth.net/">Shibboleth</a> <code>IRIDE</code> <code>HTTP</code> request header attribute.
      */
     public static final String HEADER_SHIBBOLETH_IRIDE = "Shib-Iride-IdentitaDigitale";
-
-    /**
-     * <a href="https://www.w3.org/Protocols/HTTP/HTRQ_Headers.html#z3">Accept</a> <code>HTTP</code> request header attribute.
-     */
-    public static final String HEADER_ACCEPT_JSON = "Accept=" + MediaType.APPLICATION_JSON_VALUE;
 
     /**
      * Constructor.

--- a/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceController.java
+++ b/frontend/iride-services/src/main/java/it/csi/sira/frontend/iride/controller/IrideServiceController.java
@@ -97,10 +97,7 @@ public class IrideServiceController {
      * @return
      */
     @RequestMapping(
-        headers = {
-            IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE,
-            IrideServiceConstants.HEADER_ACCEPT_JSON
-        },
+        headers = { IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE },
         value = IrideServiceConstants.MAPPING_ROLES_FOR_DIGITAL_IDENTITY
     )
     @ResponseBody

--- a/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
+++ b/frontend/iride-services/src/test/java/test/it/csi/sira/frontend/iride/controller/IrideServiceControllerTest.java
@@ -61,7 +61,6 @@ import org.springframework.web.context.WebApplicationContext;
 )
 public final class IrideServiceControllerTest {
 
-
     /**
      * Logger.
      */
@@ -123,7 +122,6 @@ public final class IrideServiceControllerTest {
                 get(url).header(IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE, this.irideIdentity.toString())
             )
             .andExpect(status().isOk())
-            .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$", hasSize(1)))
             .andExpect(jsonPath("$[0].code", is("PA_GEN_DECSIRA")))
             .andExpect(jsonPath("$[0].domain", is("REG_PMN")))
@@ -157,7 +155,6 @@ public final class IrideServiceControllerTest {
                 get(url).header(IrideServiceConstants.HEADER_SHIBBOLETH_IRIDE, "INVALID_DIGITAL_IDENTITY")
             )
             .andExpect(status().isOk())
-            .andExpect(content().mimeType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$", hasSize(0)))
             .andReturn();
 


### PR DESCRIPTION
#306 

- discarded the "`accept/json`" `HTTP` header in `Spring` `MVC` `REST` service dispatching configuration