### PR TITLE
customizzazione con le librerie di iride

### DIFF
--- a/geoserver/src/pom.xml
+++ b/geoserver/src/pom.xml
@@ -728,7 +728,7 @@
    <dependency>
     <groupId>commons-validator</groupId>
     <artifactId>commons-validator</artifactId>
-    <version>1.1.4</version>
+    <version>1.4.0</version>
    </dependency>
    <dependency>
     <groupId>commons-logging</groupId>

--- a/geoserver/src/web/app/pom.xml
+++ b/geoserver/src/web/app/pom.xml
@@ -194,11 +194,31 @@
       <artifactId>xmlunit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+     <!-- <dependency>
         <groupId>it.geosolutions.csi.sira</groupId>
         <artifactId>gs-sira-accessmanager</artifactId>
         <version>1.0-SNAPSHOT</version>
-    </dependency>
+    </dependency>-->
+	<dependency>
+		<groupId>org.geoserver.security</groupId>
+		<artifactId>sec-iride</artifactId>
+		<version>${sec-iride.version}</version>
+   </dependency>
+    <dependency>
+		<groupId>org.geoserver.security</groupId>
+		<artifactId>iride-service-client</artifactId>
+		<version>${iride-service-client.version}</version>
+   </dependency>
+    <dependency>
+		<groupId>org.geoserver.security</groupId>
+		<artifactId>iride-entities</artifactId>
+		<version>${iride-entities.version}</version>
+   </dependency>
+    <dependency>
+		<groupId>org.geoserver.security</groupId>
+		<artifactId>iride-commons</artifactId>
+		<version>${iride-commons.version}</version>
+   </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -354,6 +374,10 @@
     <sde.version>9.3</sde.version>
     <jetty.port>8080</jetty.port>
     <jetty.run.daemon>false</jetty.run.daemon>
+	<sec-iride.version>1.0-SNAPSHOT</sec-iride.version>
+	<iride-service-client.version>1.0-SNAPSHOT</iride-service-client.version>
+	<iride-entities.version>1.0-SNAPSHOT</iride-entities.version>
+	<iride-commons.version>1.0-SNAPSHOT</iride-commons.version>
   </properties>
 
   <profiles>

--- a/geoserver/src/web/app/src/main/webapp/WEB-INF/web.xml
+++ b/geoserver/src/web/app/src/main/webapp/WEB-INF/web.xml
@@ -26,6 +26,12 @@
     <param-value>PARTIAL-BUFFER2</param-value>
   </context-param>
   
+   <!-- geowebcache directory -->
+   <context-param>
+      <param-name>GEOWEBCACHE_CACHE_DIR</param-name>
+      <param-value>/appserv/tomcat60/geowebcache</param-value>
+   </context-param>
+  
   <context-param>
     <!-- see comments on the PARTIAL-BUFFER strategy -->
     <!-- this sets the size of the buffer.  default is "50" = 50kb -->

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
         <profile>
             <id>geoserver</id>
             <modules>
+				<module>security</module>
                 <module>geoserver/src</module>
             </modules>
         </profile>


### PR DESCRIPTION
Ho sostituito al gs-sira-accessmanager-1.0-SNAPSHOT.jar i 4 jar di iride sviluppati da Simone e ho modificato aggiungendo nel web.xml il riferimento a geowebcache directory.