### PR TITLE
scommentata la dipendenza di accessManager

### DIFF
--- a/geoserver/src/web/app/pom.xml
+++ b/geoserver/src/web/app/pom.xml
@@ -194,11 +194,11 @@
       <artifactId>xmlunit</artifactId>
       <scope>test</scope>
     </dependency>
-     <!-- <dependency>
+     <dependency>
         <groupId>it.geosolutions.csi.sira</groupId>
         <artifactId>gs-sira-accessmanager</artifactId>
         <version>1.0-SNAPSHOT</version>
-    </dependency>-->
+    </dependency>
 	<dependency>
 		<groupId>org.geoserver.security</groupId>
 		<artifactId>sec-iride</artifactId>


### PR DESCRIPTION
Adesso nella WEB-INF/lib di geoserver è stata aggiunta la dipendenza a gs-sira-accessmanager