### PR TITLE
aggiunta di file di configurazione

### DIFF
--- a/frontend/assets/stabilimento.json
+++ b/frontend/assets/stabilimento.json
@@ -1,0 +1,122 @@
+{
+   "featureTypeName":"siraemissioni:Stabilimento",
+   "featureTypeNameLabel":"STABILIMENTI",
+   "geometryName": "geometria",
+   "geometryType": "Point",
+   "card": {
+     "template": "assets/cardTemplate.jsxt",
+     "service": {
+       "url":"{geoserverUrl}/ows?service=WFS&request=GetFeature",
+       "params": {
+         "typeName": "siraemissioni:Stabilimento",
+         "version": "2.0",
+         "srsName": "EPSG:4326"
+       }
+     }
+   },
+   "featureinfo":{
+     "templateURL": "assets/infoTemplate.jsxt"
+   },
+   "featuregrid": {
+     "grid": {
+       "root": "/wfs:FeatureCollection/wfs:member/siraemissioni:Stabilimento",
+       "columns": [
+         {
+           "hide": true,
+           "id": true,
+           "headerName": "Id",
+           "xpath": ["@gml:id"],
+           "type": 2
+         },
+         {
+           "headerName": "Provincia",
+           "xpath": ["siraemissioni:desProvincia/text()"],
+           "type": 2
+         },
+         {
+           "headerName": "Comune",
+           "xpath": ["siraemissioni:nomeComune/text()"],
+           "type": 2
+         },
+         {
+           "headerName": "Codice Sira",
+           "xpath": ["siraemissioni:codiceSira/text()"],
+           "type": 2
+         },
+
+         {
+           "hide": true,
+           "headerName": "Geometry",
+           "xpath": ["siraemissioni:geometria/gml:Point/gml:pos/text()"],
+           "type": 6
+         }
+       ]
+     }
+   },
+   "query": {
+     "service": {
+       "url":"{geoserverUrl}/ows?service=WFS&request=GetFeature",
+       "urlParams": {
+         "version": "1.1.0",
+         "outputFormat": "application/json"
+       }
+     },
+     "fields":[
+        {
+           "index": 1,
+           "attribute": "siraemissioni:desProvincia",
+           "label":"Provincia",
+           "type":"list",
+           "valueService": {
+             "urlParams": {
+               "typeName": "sira:province"
+             }
+           },
+           "valueId":"toponimo",
+           "valueLabel":"toponimo"
+        },
+        {
+           "index": 2,
+           "attribute": "siraemissioni:nomeComune",
+           "label":"Comune",
+           "type":"list",
+           "valueService": {
+
+             "urlParams": {
+               "typeName": "sira:comuni",
+               "propertyName": "id_comune,sigla_provincia,toponimo",
+               "sortBy": "toponimo+A"
+             }
+           },
+
+           "valueId":"toponimo",
+           "valueLabel":"toponimo",
+		    "dependson":{
+              "field": "siraemissioni:desProvincia",
+              "from": "sigla",
+              "to": "sigla_provincia"
+           }
+        },
+
+        {
+           "index": 3,
+           "attribute": "siraemissioni:autorizzazioneAmbientale/siraemissioni:AutorizzazioneAmbientale/siraemissioni:tematica/siraemissioni:Tematica/siraemissioni:idTematica",
+           "label":"Tematica",
+           "type":"list",
+           "valueService": {
+
+             "urlParams": {
+               "typeName": "siradec:decsira_d_tematica",
+               "propertyName": "id_tematica,des_tematica"
+             }
+           },
+
+           "valueId":"id_tematica",
+           "valueLabel":"des_tematica"
+        }
+
+     ]
+
+   }
+
+}

--- a/security/app-schema/hale/autorizzazione_AEA.halex
+++ b/security/app-schema/hale/autorizzazione_AEA.halex
@@ -1,0 +1,16194 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hale-project version="2.9.4.release">
+    <name>autorizzazioneemissioneatomosfera</name>
+    <author>1312</author>
+    <created>2016-12-02T09:57:37.691+01:00</created>
+    <modified>2016-12-19T15:58:38.179+01:00</modified>
+    <save-config action-id="project.save" provider-id="eu.esdihumboldt.hale.io.project.hale25.xml.writer">
+        <setting name="projectFiles.separate">false</setting>
+        <setting name="target">file:/D:/progettoMapStore2/Hale_configuration/autorizzazione_AEA.halex</setting>
+        <setting name="charset">UTF-8</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.project.hale25.xml</setting>
+    </save-config>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.source" provider-id="eu.esdihumboldt.hale.io.jdbc.schema.reader">
+        <setting name="resourceId">285e84d8-7a3c-4c5e-884e-725726c950f6</setting>
+        <setting name="source">jdbc:postgresql://tst-territorio-vdb06.territorio.csi.it:5432/DBSIRASVIL</setting>
+        <setting name="jdbc.user">decsira</setting>
+        <setting name="charset">UTF-8</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.jdbc</setting>
+        <setting name="jdbc.password">mypass</setting>
+        <cache>
+            <hsd:schema xmlns:hsd="http://www.esdi-humboldt.eu/hale/schema" namespace="jdbc:postgresql:DBSIRASVIL">
+                <hsd:type-index>
+                    <hsd:entry index="0">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">accra_d_direzione_ente</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="1">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">accra_t_soggetto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="2">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bool</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="3">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bpchar</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="4">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bytea</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="5">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">date</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="6">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:dbms_pipe">db_pipes</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="7">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_d_tematica</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="8">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_d_tipo_provvedimento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="9">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_autorizzazione_emissioni</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="10">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_oggetto_associato</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="11">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_emissione_camino</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="12">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_emissione_camino_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="13">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="14">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_stabilimento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="15">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_stabilimento_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="16">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_r_tematica_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="17">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_autorizzazione_amb</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="18">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_autorizzazione_amb_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="19">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_azienda</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="20">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_azienda_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="21">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_cert_ambientale</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="22">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_dettaglio_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="23">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_imp_apparecchiatura</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="24">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_mappatura_tipo_oggetto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="25">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_abbatt</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="26">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_combust</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="27">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_emissione_camino</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="28">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_inquinante</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="29">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_provenienza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="30">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_sede_attiv_tiposede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="31">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_sottoattivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="32">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_stabilimento_ateco</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="33">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_tematica</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="34">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_tematica_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="35">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">dual</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="36">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">float8</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="37">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">geography_columns</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="38">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_autorizzazione_emissioni/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="39">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_oggetto_associato/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="40">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_emissione_camino/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="41">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_emissione_camino_old/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="42">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_impianto/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="43">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_stabilimento/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="44">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_stabilimento_old/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="45">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_pto_emissione/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="46">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_scarico/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="47">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_scarico_ass/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="48">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_sfioratore/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="49">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_sfioratore_ass/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="50">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_geo_ato/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="51">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_geo_pt_sede/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="52">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_t_comuni/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="53">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/t_aua/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="54">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/t_denorm_sede/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="55">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_aua/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="56">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_autorizzazione_emissioni/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="57">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_autorizzazione_sede_old/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="58">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_cu3_impianti_aua/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="59">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_oggetto_associato/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="60">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_emissione_camino/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="61">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_emissione_camino_old/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="62">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_impianto/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="63">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_sede/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="64">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_stabilimento/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="65">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_stabilimento_old/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="66">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_union_geo/geometria">geometry</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="67">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">geometry_columns</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="68">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">int4</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="69">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">int8</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="70">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:topology">layer</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="71">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">name</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="72">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">numeric</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="73">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">oid</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="74">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">pg_stat_statements</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="75">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:geostore">pippo</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="76">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">serial</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="77">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_abbattimento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="78">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="79">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_parametro</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="80">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_procedimento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="81">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_provenienza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="82">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_sottoattivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="83">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_stato</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="84">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_tipo_oggetto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="85">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_tipo_si</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="86">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_attiv_recupero</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="87">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_caratt_merc</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="88">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_caratt_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="89">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_categoria</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="90">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_class_fogn</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="91">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_classe_appartenenza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="92">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_codice_cer</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="93">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_combustibile</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="94">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_cost_scarico</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="95">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_criterio_assimil</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="96">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_dett_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="97">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_dispersione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="98">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_frequenza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="99">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_inquinanti</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="100">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_mod_espr</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="101">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_operaz_recupero</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="102">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_origine</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="103">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_proven_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="104">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_qta_scaricata</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="105">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_rumorosita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="106">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_settore_prod</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="107">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sost_tab3a</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="108">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sost_tabn</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="109">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sottocriterio_assim</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="110">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sponda</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="111">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_temp_ambiente</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="112">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_emissione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="113">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="114">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_prelievo</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="115">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_recettore</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="116">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_recupero</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="117">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_richiesta</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="118">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="119">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="120">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_settore</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="121">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipologia_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="122">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tratt_fango</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="123">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_trattamento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="124">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_trattamento_dep</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="125">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_udm</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="126">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_attivita_tiposede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="127">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_codass_istattivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="128">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_codass_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="129">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dep_trattdep</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="130">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dep_trattfango</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="131">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dettattiv_ist</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="132">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_istanza_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="133">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_merc_recmateria</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="134">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_prelievo_istsede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="135">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_abbatt</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="136">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_inquinante</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="137">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_prov</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="138">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_recener_param</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="139">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_ar</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="140">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_cer</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="141">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_cr</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="142">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_or</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="143">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_proven</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="144">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_cost</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="145">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_origine</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="146">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_sost_tabn</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="147">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_sprod_tab3a</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="148">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_trattamento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="149">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_sedereflui_sosttabn</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="150">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_settoreprod_istsede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="151">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_settprod_sosttab3a</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="152">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_tipimp_imprif</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="153">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_bacino_utenza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="154">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_cod_assoluto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="155">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_cod_regionale</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="156">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_depuratore</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="157">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_dest_fango</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="158">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_imp_apparecchiatura</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="159">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_imp_combust</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="160">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_macchina_tintoria</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="161">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_pto_emissione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="162">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_amb</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="163">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_energia</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="164">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_materia</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="165">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="166">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="167">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico_ass</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="168">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico_param</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="169">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scheda_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="170">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sede_reflui_ind</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="171">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sfioratore</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="172">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sfioratore_ass</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="173">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_suolo</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="174">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_geo_ato</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="175">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_geo_pt_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="176">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_fontedati</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="177">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_lingua</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="178">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_standard_espos</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="179">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_categoria</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="180">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_funzione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="181">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_oggetto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="182">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categ_lingua</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="183">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categapp_categori</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="184">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categoria_mtd</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="185">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_fm_vista_appl</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="186">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_parolachiave_mtd</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="187">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_categoria</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="188">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_categoria_appl</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="189">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_dettlog</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="190">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_funzione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="191">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_log</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="192">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_metadato</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="193">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_mtd_csw</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="194">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_mtd_plus</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="195">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_news_home_page</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="196">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_parola_chiave</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="197">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_storico_funzione</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="198">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_storico_mtd_csw</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="199">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_testi_home_page</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="200">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_istanza_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="201">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_istanza_soggetto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="202">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_proc_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="203">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_sede_attiv_pregresse</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="204">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_sottoatt_istattiv</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="205">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_comuni</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="206">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_istanza_autorizzativa</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="207">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_istanza_xml</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="208">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_province</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="209">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_raggruppamento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="210">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_ref_tecnico</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="211">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_ricircolo</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="212">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="213">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sitad_v_mg_strade</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="214">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">spatial_ref_sys</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="215">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_aua</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="216">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_codice_cer</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="217">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_operaz_recupero</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="218">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="219">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_tipo_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="220">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_scheda_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="221">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">text</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="222">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">timestamp</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="223">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">timestamptz</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="224">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:topology">topology</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="225">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:utl_file">utl_file_dir</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="226">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_attiv_rec</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="227">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_aua</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="228">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_amb</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="229">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_amb_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="230">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_emissioni</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="231">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_sede_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="232">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="233">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="234">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda_old_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="235">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_caratt_rec_mat</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="236">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_caratt_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="237">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_codice_cer</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="238">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_cu3_impianti_aua</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="239">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dettaglio_attivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="240">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dict_operaz_rec</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="241">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dict_tipo_rif</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="242">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_imp_apparecchiatura</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="243">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_istanza_autorizzativa</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="244">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_oggetto_associato</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="245">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_operaz_recupero</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="246">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_proven_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="247">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_abbatt</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="248">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_combust</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="249">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_emissione_camino</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="250">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_emissione_camino_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="251">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="252">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_inquinante</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="253">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_provenienza</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="254">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rec_ener</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="255">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rec_ener_param</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="256">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="257">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_scheda_rifiuto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="258">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="259">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sede_attiv_tiposede</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="260">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sottoattivita</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="261">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_stabilimento</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="262">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_stabilimento_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="263">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tematica</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="264">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tematica_old</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="265">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tipo_impianto</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="266">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_union_geo</hsd:name>
+                    </hsd:entry>
+                    <hsd:entry index="267">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">varchar</hsd:name>
+                    </hsd:entry>
+                </hsd:type-index>
+                <hsd:mapping-relevant>0 1 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 37 67 70 74 75 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256 257 258 259 260 261 262 263 264 265 266</hsd:mapping-relevant>
+                <hsd:types>
+                    <hsd:type index="0">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">accra_d_direzione_ente</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>civico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>email_pec</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descr_direzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="223"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ufficio_deposito</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>servizio_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_direzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="1">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">accra_t_soggetto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>flg_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_cessazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="223"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>num_telefono</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>civico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo_non_trovato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>email_pec</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_natura_giuridica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_fonte</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fax</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>prov_cciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>anno_cciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>numero_cciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_nascita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="223"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_nazione_nascita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_nazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>citta_estera_nascita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>citta_estera_residenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="2">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bool</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Boolean"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="3">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bpchar</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.String"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="4">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">bytea</hsd:name>
+                        <hsd:constraint type="binding" value="[B"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="5">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">date</hsd:name>
+                        <hsd:constraint type="binding" value="java.sql.Date"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="6">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:dbms_pipe">db_pipes</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>items</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>size</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>limit</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>private</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="2"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>owner</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="7">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_d_tematica</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tematica</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="8">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_d_tipo_provvedimento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_proc_attivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_proc_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provv</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="9">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_autorizzazione_emissioni</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_autorizz</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>presenza_emissioni_diffuse</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_autorizzazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="38"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="10">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_oggetto_associato</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>identificativo</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_prov_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="39"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="11">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_emissione_camino</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>identificativo</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aeriforme</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temperatura_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secondo_lato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="40"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="12">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_emissione_camino_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aeriforme</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temperatura_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secondo_lato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="41"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="13">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_pto_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_punto_impianto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="42"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="14">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_stabilimento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>codice_sira</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>email_pec</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ind_agroalim</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ricircolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modalita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prelevata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_anno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_giorno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provv_attivi</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provv_storici</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>idtipoimp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>destipoimp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_equiv_trattati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="43"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="15">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_geo_stabilimento_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="44"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="16">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_r_tematica_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="17">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_autorizzazione_amb</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_autorizzamb_sede</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizzamb_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_scadenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="18">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_autorizzazione_amb_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_autorizzamb_sede</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizzamb_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="19">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_azienda</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_imp_azienda</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>telefono</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fax</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cognome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>numero_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>anno_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="20">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_azienda_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="21">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_cert_ambientale</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_cert_amb</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_cert_amb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_certificazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_cert_amb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_rilascio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="22">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_dettaglio_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_dettaglio_attivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dettaglio_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_dett_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>quantita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="23">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_imp_apparecchiatura</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_scheda_rifiuto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_apparecchiatura</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_oraria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_giorn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>p_perc_matprima_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="24">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_mappatura_tipo_oggetto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_oggetto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_tabella</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>feature_type</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="25">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_abbatt</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_punto_abbatt</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_abbatt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="26">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_combust</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_imp_combust</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipologia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>potenza_singolo_focolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>consumo_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_udm</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_monitoraggio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>civile_industriale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="27">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_emissione_camino</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aeriforme</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipologia_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temperatura_atmosferica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secondo_lato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale_costruzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="28">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_inquinante</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_punto_inquinante</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>concentrazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flusso_massa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="29">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_pto_provenienza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_punto_prov</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_prov</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>impianti_interessati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altra_provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="30">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_sede_attiv_tiposede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sede_attiv_ts</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sede_attiv_ts</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="31">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_sottoattivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sottoattivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sottoattivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_sottoattivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="32">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_stabilimento_ateco</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_stab_ateco</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_stab_ateco</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_ateco</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_ateco</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="33">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_tematica</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>identificativo</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="34">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">decsira_t_tematica_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tematica</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="35">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">dual</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>dummy</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="36">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">float8</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Double"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="37">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">geography_columns</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>f_table_catalog</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="71"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_table_schema</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="71"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_table_name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="71"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_geography_column</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="71"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_dimension</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>srid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>type</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="38">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_autorizzazione_emissioni/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="39">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_oggetto_associato/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="40">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_emissione_camino/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="41">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_emissione_camino_old/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="42">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_pto_impianto/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="43">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_stabilimento/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="44">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/decsira_geo_stabilimento_old/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="45">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_pto_emissione/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="46">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_scarico/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="47">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_scarico_ass/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="48">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_sfioratore/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="49">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_dt_t_sfioratore_ass/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="50">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_geo_ato/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="51">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_geo_pt_sede/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="52">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/sipra_t_comuni/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="53">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/t_aua/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="54">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/t_denorm_sede/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="55">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_aua/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="56">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_autorizzazione_emissioni/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="57">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_autorizzazione_sede_old/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="58">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_cu3_impianti_aua/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="59">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_oggetto_associato/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="60">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_emissione_camino/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="61">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_emissione_camino_old/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="62">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_pto_impianto/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="63">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_sede/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="64">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_stabilimento/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="65">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_stabilimento_old/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="66">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira/v_union_geo/geometria">geometry</hsd:name>
+                        <hsd:constraint type="binding" value="eu.esdihumboldt.hale.common.schema.geometry.GeometryProperty"/>
+                        <hsd:constraint type="geometry-type" value="com.vividsolutions.jts.geom.Geometry"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="67">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">geometry_columns</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>f_table_catalog</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_table_schema</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_table_name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>f_geometry_column</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_dimension</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>srid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>type</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="68">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">int4</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Integer"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="69">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">int8</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Long"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="70">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:topology">layer</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>topology_id</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="224"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>layer_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>schema_name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>table_name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>feature_column</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>feature_type</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>level</hsd:name>
+<hsd:constraint type="cardinality" value="0..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>child_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="71">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">name</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.String"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="72">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">numeric</hsd:name>
+                        <hsd:constraint type="binding" value="java.math.BigDecimal"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="73">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">oid</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Long"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="74">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">pg_stat_statements</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>userid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="73"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>dbid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="73"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>query</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>calls</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>total_time</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="36"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>rows</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>shared_blks_hit</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>shared_blks_read</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>shared_blks_dirtied</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>shared_blks_written</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>local_blks_hit</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>local_blks_read</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>local_blks_dirtied</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>local_blks_written</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_blks_read</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_blks_written</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="69"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>blk_read_time</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="36"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>blk_write_time</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="36"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="75">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:geostore">pippo</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="76">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">serial</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.Integer"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="77">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_abbattimento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="78">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_attivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="79">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_parametro</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_parametro</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_parametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_parametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cas</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="80">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_procedimento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_procedimento</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_visualizza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_bdc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="81">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_provenienza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="82">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_sottoattivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>progressivo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_sottoattivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="83">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_stato</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_stato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sequenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>oggetto_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato_relativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_tipologia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="84">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_tipo_oggetto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_oggetto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="85">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_d_tipo_si</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_si</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_si</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_si</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_nuovo_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="86">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_attiv_recupero</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_attiv_recupero</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_attiv_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_att_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attiv_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="87">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_caratt_merc</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_caratt_merc</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="88">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_caratt_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_caratt_rifiuto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="89">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_categoria</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_categoria</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="90">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_class_fogn</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_class_fogn</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_class_fogn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_class_fogn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="91">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_classe_appartenenza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_classe_appartenenza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_classe_appartenenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_classe_appartenenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="92">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_codice_cer</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>codice_cer</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="93">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_combustibile</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_combustibile</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="94">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_cost_scarico</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_cost_scarico</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_cost_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_cost_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="95">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_criterio_assimil</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_criterio</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_criterio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_criterio_assimil</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="96">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_dett_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_dett_attivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dett_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_dett_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_categoria</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="89"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="97">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_dispersione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_dispersione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dispersione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_dispersione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="98">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_frequenza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_frequenza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_frequenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_frequenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="99">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_inquinanti</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_inquinante</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="100">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_mod_espr</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_mod_espr</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_mod_espr</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_mod_espr</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="101">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_operaz_recupero</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_operaz_recupero</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="102">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_origine</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_origine</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_origine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_padre_origine</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="102"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_origine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="103">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_proven_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_proven_rifiuto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="104">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_qta_scaricata</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_qta_scaricata</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_qta_scaricata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_qta_scaricata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="105">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_rumorosita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_rumorosita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_rumorosita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_rumorosita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="106">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_settore_prod</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_settore_prod</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_settore_prod</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_settore_prod</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_settore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="120"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="107">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sost_tab3a</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sostanza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="108">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sost_tabn</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sostanza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cas</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>rif_tab_allegati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="109">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sottocriterio_assim</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sottocriterio</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sottocriterio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_criterio</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="95"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_sottocriterio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="110">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_sponda</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sponda</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sponda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_sponda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="111">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_temp_ambiente</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_temp_ambiente</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_temp_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_temp_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="112">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_emissione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_emissione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="113">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_impianto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="114">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_prelievo</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_prelievo</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_prelievo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_prelievo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="115">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_recettore</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_recettore</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_recettore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_recettore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="116">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_recupero</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_recupero</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="117">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_richiesta</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_richiesta</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_modulo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="118">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_rifiuto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="119">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_sede</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="120">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipo_settore</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_settore</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_settore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tiposettore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="121">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tipologia_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipologia_impianto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipologia_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipologia_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="122">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_tratt_fango</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tratt_fango</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tratt_fango</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tratt_fango</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="123">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_trattamento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_trattamento</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_trattamento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_trattamento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="124">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_trattamento_dep</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_trattamento_dep</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_trattamento_dep</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_padre</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="124"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_trattamento_dep</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="125">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_d_udm</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_udm</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_udm</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_udm</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="126">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_attivita_tiposede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_sede</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="119"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="127">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_codass_istattivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_r_codass_istademp</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_r_codass_istademp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="154"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_oggetto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="84"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>identificativo_oggetto_fe</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="128">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_codass_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_r_codass_sede</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_r_codass_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_r_codass_istademp</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="127"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ragione_sociale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="129">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dep_trattdep</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_trattamento_dep</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="124"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_depuratore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="156"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>spec_tratt_specifico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altra_filtr</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="130">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dep_trattfango</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tratt_fango</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="122"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_depuratore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="156"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secco_ta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="131">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_dettattiv_ist</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_dettattiv_ist</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dettattiv_ist</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_dett_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="96"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>quantita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>potenzialita_t_gg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>potenzialita_k_gg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>umidita_perc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_termica_kw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_utilizz_kg_h</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="132">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_istanza_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_richiesta</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="117"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nota_quadro_tecnico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_atto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_ente_accra</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_scadenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note_atto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_diffusa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note_emiss_diffuse</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiali_produzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipologia_impianto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="121"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="133">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_merc_recmateria</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_caratt_merc</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="87"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="164"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="164"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="164"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>destinazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="134">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_prelievo_istsede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_prelievo</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="114"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>volume_medio_anno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>volume_medio_giorn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_misuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro_tipo_prel</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione_gestore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="135">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_abbatt</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_abbattimento</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="77"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="161"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="77"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="136">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_inquinante</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="161"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_inquinante</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="99"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>concentrazione_mgnm3</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flusso_massa_kgh</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="137">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_ptoemiss_prov</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_provenienza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="81"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="161"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="81"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>imp_interessati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altra_provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="138">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_recener_param</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="163"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_parametro</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="79"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="163"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="163"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_altro_param</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_validita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="139">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_ar</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attiv_recupero</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="86"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="140">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_cer</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cer</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="92"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="141">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_cr</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_caratt_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="88"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="142">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_or</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_operaz_recupero</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="101"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_gest</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="143">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_rifiuto_proven</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_proven_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="103"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="144">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_cost</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_cost_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="94"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="145">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_origine</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_origine</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="102"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_criterio</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="95"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_media</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_media_estiva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_media_invernale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_sottocriterio</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="109"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="146">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_sost_tabn</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sostanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="108"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_qta_scaricata</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="104"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pres_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>quantita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>concentr_media</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>limite_qta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pres_insed</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="147">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_sprod_tab3a</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_settprod_sosttab3a</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="151"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>media_mensile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>media_giorno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="148">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_scarico_trattamento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_trattamento</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="123"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro_trattamento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="149">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_sedereflui_sosttabn</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sede_reflui_ind</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="170"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_sostanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="108"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altra_sostanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>concentr_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="150">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_settoreprod_istsede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_settore_prod</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="106"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="151">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_settprod_sosttab3a</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_settprod_sosttab3a</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_settprod_sosttab3a</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_settore_prod</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="106"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_sostanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="107"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_mod_espr</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="100"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="152">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_r_tipimp_imprif</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="165"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_impianto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="113"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="165"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="153">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_bacino_utenza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_bacino_utenza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_bacino_utenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_localita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>localita_non_trovata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_depuratore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="156"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="154">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_cod_assoluto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>cod_assoluto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_oggetto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="84"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="155">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_cod_regionale</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>cod_regionale_scarico</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>cod_regionale_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="154"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="156">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_depuratore</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_depuratore</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_depuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_org_progetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_residenti</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_fluttuanti</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_equiv_industriali</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_media_annua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_declassato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_acque_met</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_riutil_agricolt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_riutil_ind</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_riutil_altro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>riutil_altro_note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_acque_riutil</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_equiv_rif_liq</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_equiv_trattati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_class_fogn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_determ</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_determ</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fanghi_prod_ta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_secco_fango</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="83"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_regionale_imp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_europeo_imp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>numero_pratica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="157">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_dest_fango</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dest_fango</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tratt_fango</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="130"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_depuratore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="130"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denom_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="158">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_imp_apparecchiatura</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>nr_apparecchiatura</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_apparecchiatura</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_oraria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_giorn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>p_perc_matprima_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_validita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="159">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_imp_combust</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_imp_combust</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_pto_emissione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="161"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_combustibile</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="93"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_udm_combust</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="125"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipologia_impianto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="121"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla_imp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipologia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>potenza_focol_mwt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>consumo_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_sistema_monit</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="160">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_macchina_tintoria</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_r_codass_istademp</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="127"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>progressivo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modello</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>volume_tamb_m3</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_solvente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_solvente_kg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_prodotto_pulito_kg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="161">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_pto_emissione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_pto_emissione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_r_codass_istademp</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="127"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="83"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_temp_ambiente</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="111"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_frequenza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="98"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla_pto_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aerif_nm3h</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emiss_hg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza_emiss_m</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro1_m</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro2_m</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale_camino</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_emissione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="112"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="45"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_validita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="162">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_amb</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla_prov</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_civico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>consiste_in</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo_progetto_amb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>approvato_da</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_provved_approv</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provved_approv</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_impieg_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_impieg_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_rifiuti</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>desc_mod_utilizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_validita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="163">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_energia</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_impiego_sim_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>mod_utilizzo_energia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>accordi_aziende</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_termica_mwt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_termica_mwe</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>calore_mwh</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>energia_elettr_mwh</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_rend_energ</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_validita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_alim_autom_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_controllo_param</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_impiego_sim_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="164">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_recupero_materia</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="169"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_anno_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prodotto_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="165">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_classe_appartenenza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="91"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_tot_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_iscr_provinciale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_iscr_provinciale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_scadenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="166">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_scarico</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_r_codass_istademp</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="127"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="83"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_recettore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="115"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_frequenza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="98"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_attivo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_misuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>freq_h_giorno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>freq_gg_settimana</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>freq_mesi_anno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>freq_periodo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_media</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_max</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>volume_annuo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_x_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_y_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo_fognatura</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione_corpo_idrico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="46"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>volume_invaso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_minima</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_portata_nulla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_naturale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_acque_reflue</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_acque_lim_port</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_sfioratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="167">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico_ass</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>cod_assoluto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="154"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_sponda</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="110"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_recettore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_x_assoluta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_y_assoluta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="47"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="168">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scarico_param</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_scarico_param</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scarico_param</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_udm</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="125"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_parametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>lim_inf_mgl</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_misura</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="169">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_scheda_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_recupero</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="116"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="118"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="170">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sede_reflui_ind</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sede_reflui_ind</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sede_reflui_ind</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_giorn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ragione_sociale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_depuratore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="156"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="171">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sfioratore</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_sfioratore</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sfioratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_r_codass_istademp</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="127"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="83"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_recettore</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="115"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>num_ae_fogn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_x_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_y_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_media</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_attivaz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_innesco</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizo_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine_val</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="3"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_provvisorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione_recettore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_naturale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="48"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="172">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_sfioratore_ass</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>cod_assoluto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="154"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_x</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_y</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="49"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="173">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_dt_t_suolo</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_scarico</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scarico</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="166"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_dispersione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="97"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>distanza_corso_acqua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>motivo_no_recapito</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>caratt_terreno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro_pozzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza_pozzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>delta_pozzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>lungh_trincea</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>area_trincea</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="174">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_geo_ato</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_ato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_ato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="50"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="175">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_geo_pt_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>codice_sira</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="36"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="51"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="176">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_fontedati</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_fontedati</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_fontedati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_standard_espos</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="178"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_fontedati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url_prefisso_metadato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url_servizio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_attiva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>prefisso_fontedati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="177">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_lingua</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_lingua</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_lingua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_lingua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="178">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_standard_espos</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_standard_espos</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_standard_espos</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_standard_espos</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="179">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_categoria</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_categoria</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="180">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_funzione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_funzione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_funzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_funzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>protocollo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="181">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_d_tipo_oggetto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_tipo_oggetto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="182">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categ_lingua</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="187"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_lingua</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="177"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_alias</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_alias</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="183">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categapp_categori</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria_appl</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="188"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_categoria</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="187"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="184">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_categoria_mtd</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="187"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="185">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_fm_vista_appl</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_funzione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="190"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_metadato_figlio</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="186">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_r_parolachiave_mtd</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_parola_chiave</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="196"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="187">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_categoria</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_categoria</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_categoria</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="179"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="188">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_categoria_appl</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_categoria_appl</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_categoria_appl</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_padre</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="188"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>livello</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_categoria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url_icona</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>object_number</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>view_number</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="189">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_dettlog</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_dett_log</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dett_log</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_log</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="191"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_errore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="190">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_funzione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_funzione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_funzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_funzione</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="180"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>request_url</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="191">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_log</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_log</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_log</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_log</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_log</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="192">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_metadato</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_metadato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_metadato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_fontedati</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="176"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_metadato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_ult_agg</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="193">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_mtd_csw</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_metadato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>dc_identifier</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>testo_abstract</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_metadato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url_metadato_calc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_crs</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_lower_corner</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_upper_corner</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="194">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_mtd_plus</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_metadato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_oggetti_dataset_calc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_oggetto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="181"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="195">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_news_home_page</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_news</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_news</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo_news</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abstract_news</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>priorita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="196">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_parola_chiave</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_parola_chiave</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_parola_chiave</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_parola_chiave</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="197">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_storico_funzione</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_storico_funzione</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_storico_funzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_funzione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>request_url</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="198">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_storico_mtd_csw</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_storico_metadato</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_storico_metadato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="192"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>dc_identifier</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>testo_abstract</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_metadato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url_metadato_calc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_crs</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_lower_corner</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>bound_box_upper_corner</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="199">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_mtd_t_testi_home_page</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_testo</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_testo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_testo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo_testo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abstract_testo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="200">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_istanza_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="212"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_suap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>carico_organico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="201">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_istanza_soggetto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_r_istanza_soggetto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_r_istanza_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_si</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="85"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_raggruppamento</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="209"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_soggetto_accra</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_fine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="202">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_proc_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_proc_attivita</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_proc_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_procedimento</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="80"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_modulo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_gestione_interna</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modulo_pdf</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ordine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_sede_operativa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pref_codice_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_accra_tipo_sogg_autorita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_gestito_suap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_scelta_autorita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_objrw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_gg_calcolo_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_ist_persist</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_dt_tecnici</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>metodo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_ist_persist_geo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_dt_geo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>file_xslt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_georif_obbligatorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_modifica_qtecnico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_be</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_be</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_arada</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_arada</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_arada_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_arada_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modulo_qt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_sedi_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="203">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_sede_attiv_pregresse</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="212"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="78"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_ente_accra</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>rilasciato_da</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_atto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note_atto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="204">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_r_sottoatt_istattiv</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita_istatt</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="132"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="82"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>progressivo</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="82"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="205">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_comuni</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_comune</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="3"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla_provincia</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="208"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="52"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="206">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_istanza_autorizzativa</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_istanza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_proc_attivita</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="202"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_utente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inserimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="222"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>progressivo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_modulo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_pratica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>num_pratica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_provenienza_esterna</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_richiesta</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="117"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_rilascio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="207">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_istanza_xml</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_tipofile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>file_xml</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>file_pdf</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="4"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_in_lavorazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inizio_elab</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_utente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="208">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_province</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_provincia</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="3"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="209">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_raggruppamento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_raggruppamento</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_raggruppamento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="210">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_ref_tecnico</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_istanza</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cognome</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>telefono</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>e_mail</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ruolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="211">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_ricircolo</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="200"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_anno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_giorno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modalita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prelevata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="212">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sipra_t_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>codice_sira</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_utmx</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_utmy</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_depuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_ato</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="174"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="213">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">sitad_v_mg_strade</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_l1</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_localita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipovia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_nomevia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_via</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>preposizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_via</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>canc_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_cod_utente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_modifica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="223"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_uff</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_geo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="214">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:public">spatial_ref_sys</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>srid</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>srid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>auth_name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>auth_srid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>srtext</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>proj4text</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="215">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_aua</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>gml_id</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>gml_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nota_quadro_tecnico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_rilascio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_bdc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_tot_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="53"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="216">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_codice_cer</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>gml_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="220"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="217">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_operaz_recupero</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>gml_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="220"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_gest</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="218">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>gml_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_depuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="54"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="206"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="219">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_denorm_tipo_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>gml_id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="215"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="220">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">t_scheda_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id_scheda_rifiuto</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="reference">
+    <core:properties xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+        <core:property name="referencedTypes">
+            <core:value>
+                <core:list>
+                    <core:entry value="215"/>
+                </core:list>
+            </core:value>
+        </core:property>
+        <core:property name="isReference">
+            <core:value value="true"/>
+        </core:property>
+    </core:properties>
+</hsd:constraint>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>gml_id_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_anno_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prodotto_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="221">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">text</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.String"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="222">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">timestamp</hsd:name>
+                        <hsd:constraint type="binding" value="java.sql.Timestamp"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="223">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">timestamptz</hsd:name>
+                        <hsd:constraint type="binding" value="java.sql.Timestamp"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                    <hsd:type index="224">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:topology">topology</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="primary-key">
+                            <core:list xmlns:core="http://www.esdi-humboldt.eu/hale/core">
+<core:entry>
+    <core:name>id</core:name>
+</core:entry>
+                            </core:list>
+                        </hsd:constraint>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id</hsd:name>
+<hsd:constraint type="cardinality" value="0..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="76"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>name</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>srid</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>precision</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="36"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>hasz</hsd:name>
+<hsd:constraint type="cardinality" value="0..1"/>
+<hsd:constraint type="nillable" value="false"/>
+<hsd:propertyType index="2"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="225">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:utl_file">utl_file_dir</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>dir</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="226">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_attiv_rec</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attiv_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_att_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attiv_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="227">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_aua</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_aua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="55"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="228">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_amb</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizzamb_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_scadenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="229">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_amb_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizzamb_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="230">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_emissioni</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>presenza_emissioni_diffuse</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_autorizzazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="56"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="231">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_autorizzazione_sede_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_autorizz_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="57"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="232">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>telefono</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fax</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cognome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>numero_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>anno_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="233">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="234">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_azienda_old_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>toponimo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>telefono</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fax</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cognome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_titolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>numero_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>anno_ciaa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="235">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_caratt_rec_mat</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>destinazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_caratt_merc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="236">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_caratt_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_caratt_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="237">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_codice_cer</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_cer</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="238">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_cu3_impianti_aua</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>denominazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_fiscale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>partita_iva</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_l2</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune_azienda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>estremi_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ente_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="58"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="239">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dettaglio_attivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_dettaglio_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_dett_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>quantita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="240">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dict_operaz_rec</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>label</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="241">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_dict_tipo_rif</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>label</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="242">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_imp_apparecchiatura</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_apparecchiatura</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_oraria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_max_giorn</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>p_perc_matprima_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="243">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_istanza_autorizzativa</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_proc_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_utente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cf_soggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_inserimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="222"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>titolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>progressivo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_modulo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_pratica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>num_pratica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_provenienza_esterna</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_provvedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_rilascio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_proc_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_modulo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_gestione_interna</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>url</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modulo_pdf</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ordine</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_sede_operativa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pref_codice_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_accra_tipo_sogg_autorita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_gestito_suap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_scelta_autorita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_objrw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_istat</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_gg_calcolo_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_ist_persist</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_dt_tecnici</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>metodo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_ist_persist_geo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_stato_dt_geo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>file_xslt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_georif_obbligatorio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fl_modifica_qtecnico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_be</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_be</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_arada</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_arada</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_arada_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_obj_arada_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modulo_qt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>config_vgeo_sedi_rw</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_procedimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_bdc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="244">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_oggetto_associato</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_oggetto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>cod_assoluto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_prov_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="59"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="245">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_operaz_recupero</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_gest</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_operaz_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="246">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_proven_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_proven_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="247">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_abbatt</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_abbatt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="248">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_combust</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_imp_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipologia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>potenza_singolo_focolare</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>consumo_combust</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_udm</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_monitoraggio</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>civile_industriale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="249">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_emissione_camino</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aeriforme</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temperatura_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secondo_lato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="60"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="250">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_emissione_camino_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sigla</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>portata_aeriforme</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>durata_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>frequenza_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_costante_discontinua</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temp_emiss</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>temperatura_ambiente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>sistema_abbattimento</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>note</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altezza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>diametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>secondo_lato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>materiale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_autorita_competente</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="61"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="251">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="62"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="252">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_inquinante</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>concentrazione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flusso_massa</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altro_inquinante</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="253">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_pto_provenienza</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_punto_prov</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_pto_emissione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>impianti_interessati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>altra_provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provenienza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="254">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rec_ener</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_alim_autom_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_controllo_param</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_impiego_sim_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_impiego_sim_comb</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>mod_utilizzo_energia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>accordi_aziende</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_termica_mwt</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>pot_termica_mwe</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>calore_mwh</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>energia_elettr_mwh</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_rend_energ</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>combustibile</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="255">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rec_ener_param</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_parametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_altro_param</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_parametro</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_cas</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="256">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_classe_appartenenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_tot_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_t</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>capacita_max_stocc_mc</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_iscr_provinciale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_iscr_provinciale</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>data_scadenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="5"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nota_quadro_tecnico</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_classe_appartenenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_classe_appartenenza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_richiesta</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="257">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_scheda_rifiuto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_scheda_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nr_scheda</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_pericoloso_tipo_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>qta_anno_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prodotto_recupero</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="258">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_utmx</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>coord_utmy</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>flg_depuratore</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>fk_suap</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="63"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="259">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sede_attiv_tiposede</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sede_attiv_ts</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_sede</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="260">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_sottoattivita</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_sottoattivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>tipo_sottoattivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="261">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_stabilimento</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>nome</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>indirizzo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>email_pec</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ind_agroalim</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>ricircolo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>modalita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>perc_prelevata</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_anno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>vol_giorno</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_stato</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provv_attivi</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provv_storici</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>idtipoimp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>destipoimp</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>abitanti_equiv_trattati</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="64"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="262">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_stabilimento_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_autorizz</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>istat_comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>comune</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>provincia</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="65"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="263">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tematica</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>identificativo</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="264">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tematica_old</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_tematica</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>descrizione</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>codice_sira</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="265">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_tipo_impianto</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_rifiuto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="221"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="68"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>id_attivita</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>des_tipo_impianto</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="267"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="266">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL:decsira">v_union_geo</hsd:name>
+                        <hsd:constraint type="has-value" value="false"/>
+                        <hsd:constraint type="mapping-relevant" value="true"/>
+                        <hsd:constraint type="mappable" value="true"/>
+                        <hsd:declares>
+                            <hsd:property>
+<hsd:name>id_istanza</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="72"/>
+                            </hsd:property>
+                            <hsd:property>
+<hsd:name>geometria</hsd:name>
+<hsd:constraint type="cardinality" value="1..1"/>
+<hsd:constraint type="nillable" value="true"/>
+<hsd:propertyType index="66"/>
+                            </hsd:property>
+                        </hsd:declares>
+                    </hsd:type>
+                    <hsd:type index="267">
+                        <hsd:name namespace="jdbc:postgresql:DBSIRASVIL">varchar</hsd:name>
+                        <hsd:constraint type="binding" value="java.lang.String"/>
+                        <hsd:constraint type="has-value" value="true"/>
+                        <hsd:constraint type="mapping-relevant" value="false"/>
+                    </hsd:type>
+                </hsd:types>
+            </hsd:schema>
+        </cache>
+    </resource>
+    <resource action-id="eu.esdihumboldt.hale.io.schema.read.target" provider-id="eu.esdihumboldt.hale.io.xsd.reader">
+        <setting name="resourceId">2f5a0d69-a317-438e-9f05-47fe4bac344d</setting>
+        <setting name="source">file:/D:/progettoMapStore2/Hale_configuration/sipra_AEA.xsd</setting>
+        <setting name="onlyElementsMappable">true</setting>
+        <setting name="charset">UTF-8</setting>
+        <setting name="contentType">eu.esdihumboldt.hale.io.xsd</setting>
+    </resource>
+    <file name="styles.sld" location="autorizzazione_AEA.halex.styles.sld"/>
+    <file name="alignment.xml" location="autorizzazione_AEA.halex.alignment.xml"/>
+    <property name="compatibilityMode">eu.esdihumboldt.hale.io.appschema.compatibility</property>
+    <property name="defaultGeometry:{http://www.regione.piemonte.it/ambiente/siraemissioni/1.0}StabilimentoType/1">{http://www.regione.piemonte.it/ambiente/siraemissioni/1.0}geometria</property>
+    <property name="defaultGeometry:{http://www.regione.piemonte.it/ambiente/siraemissioni/1.0}StabilimentoType/2">{http://www.opengis.net/gml/3.2/AbstractGeometry}choice</property>
+    <property name="defaultGeometry:{http://www.regione.piemonte.it/ambiente/siraemissioni/1.0}StabilimentoType/count">2</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_autorizzazione_emissioni/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_autorizzazione_emissioni/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_oggetto_associato/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_oggetto_associato/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_emissione_camino/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_emissione_camino/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_emissione_camino_old/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_emissione_camino_old/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_impianto/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_pto_impianto/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_stabilimento/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_stabilimento/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_stabilimento_old/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_stabilimento_old/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_pto_emissione/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_pto_emissione/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_scarico/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_scarico/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_scarico_ass/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_scarico_ass/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_sfioratore/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_sfioratore/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_sfioratore_ass/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_dt_t_sfioratore_ass/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_geo_ato/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_geo_ato/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_geo_pt_sede/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_geo_pt_sede/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_t_comuni/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}sipra_t_comuni/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}t_aua/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}t_aua/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}t_denorm_sede/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}t_denorm_sede/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_aua/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_aua/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_autorizzazione_emissioni/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_autorizzazione_emissioni/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_autorizzazione_sede_old/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_autorizzazione_sede_old/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_cu3_impianti_aua/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_cu3_impianti_aua/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_oggetto_associato/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_oggetto_associato/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_emissione_camino/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_emissione_camino/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_emissione_camino_old/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_emissione_camino_old/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_impianto/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_pto_impianto/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_sede/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_sede/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_stabilimento/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_stabilimento/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_stabilimento_old/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_stabilimento_old/count">1</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_union_geo/1">geometria</property>
+    <property name="defaultGeometry:{jdbc:postgresql:DBSIRASVIL:decsira}v_union_geo/count">1</property>
+    <property name="mappableSourceType/1">{jdbc:postgresql:DBSIRASVIL:decsira}decsira_t_tematica</property>
+    <property name="mappableSourceType/2">{jdbc:postgresql:DBSIRASVIL:decsira}decsira_t_autorizzazione_amb</property>
+    <property name="mappableSourceType/3">{jdbc:postgresql:DBSIRASVIL:decsira}decsira_geo_stabilimento</property>
+    <property name="mappableSourceType/count">3</property>
+    <property name="target.url.history/1">http://tst-gisserver2.territorio.csi.it:8080/geoserver</property>
+    <property name="target.url.history/count">1</property>
+</hale-project>

--- a/security/app-schema/hale/autorizzazione_AEA.halex.alignment.xml
+++ b/security/app-schema/hale/autorizzazione_AEA.halex.alignment.xml
@@ -1,0 +1,775 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alignment xmlns="http://www.esdi-humboldt.eu/hale/alignment">
+    <cell relation="eu.esdihumboldt.hale.align.retype" id="Cb56d4e2d-a544-4407-9aa0-fed06ca25333" priority="normal">
+        <source>
+            <class>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </class>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C49322212-dfae-48da-87c1-ca453c775092" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="abitanti_equiv_trattati"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="abitantiEquivalentiTrattati" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cbcf44ffb-2cdf-4e8f-a440-5c3d2c882cc8" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="codice_sira"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="codiceSira" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C3d141be7-5132-4a66-b63c-f1912cd0b89e" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="comune"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="nomeComune" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cd67765c4-a4b2-45eb-b14d-d85eafeb4ffc" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="des_stato"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desStato" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C9c4c6ec1-46a7-40b8-b7c7-d3354ceeb1e4" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="des_tematica"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="tematica" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C26d57a3c-afcb-4df5-85c4-70975a3b1e5d" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="destipoimp"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desTipologiaImpianto" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Ca1e8fc23-f35c-4db1-8c51-07c37055b3c0" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="email_pec"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="emailPec" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C9a7b8041-0d13-4a93-bf98-6ef78f753dc9" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="geometria"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="geometria" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C73afb768-19e3-4ca2-b1ce-119e2622450d" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_stato"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idStato" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C12cdbbdb-93f2-4ac5-9430-4ca1a9d60a60" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="idtipoimp"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idTipologiaImpianto" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cc614f1f0-8ab8-445b-9ca2-72f93982c435" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="ind_agroalim"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="industriaAgroAlimentare" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C72e92e2f-1045-4eb0-b98f-7df0c1212407" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="indirizzo"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="indirizzo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cfdd93f11-c023-43f8-81c9-dac43f746dc4" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="istat_comune"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="istatComune" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C210165e6-b107-4601-a586-1ba61bd57fa2" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="istat_provincia"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="istatProvincia" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C706d1ba4-7e24-4f9f-9a45-064a3ab99dc9" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="modalita"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="modalitaRicircolo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cbd7c7b1a-ed63-4c27-b59e-255f5a8a3966" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="nome"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="nome" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cc2203841-e478-4729-8657-8c820c0dda53" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="perc_prelevata"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="percentualeRicircolo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C48ed0cad-952d-4a74-a10a-68ef6baeba95" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="provincia"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desProvincia" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Ce2edad37-0d27-40b1-9f13-3f7b364bf728" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="provv_attivi"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="tipoProvvedimentoAttivo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C56ee9a1e-3b76-45fa-9afd-6186db916df2" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="provv_storici"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="tipoProvvedimentoStorico" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C919f380c-36f9-4bff-b6ed-153259f1b465" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="ricircolo"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="ricircoloInterno" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Ced3c74a4-7c9a-446e-8981-0048e4fab0b9" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="vol_anno"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="volumeAnnuoRicircolo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C40bdd643-6d1a-4b6c-9470-a186d6f02d5f" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="vol_giorno"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="volumeGiornoRicircolo" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.retype" id="Ce1b8bf10-27c1-4659-a27e-f8dd26457e7e" priority="normal">
+        <source>
+            <class>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </class>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C248df8a3-4938-4cac-93f0-e648262a3348" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="codice_sira"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="codiceSira" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C0270f59d-17f1-46d7-82c7-e2fcfb953b21" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="data_provvedimento"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="dataProvvedimento" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C572619ba-980d-47b8-97da-3ff607d18120" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="data_scadenza"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="dataScadenza" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cf29d08fc-4ee8-48bb-a564-62b69459e154" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="des_stato"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desStato" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C73807106-ef51-43f3-839d-6bf5f75f819d" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="des_tematica"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desTematica" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C60dc738f-0f48-410a-b5de-b625c6542e3b" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="ente_competente"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="desEnteCompetente" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C89113e03-f353-474b-b9b6-ce91c81df890" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="estremi_provvedimento"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="estremiProvvedimento" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cf18796fc-e22f-4abc-90e4-b2de611763e6" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="fk_autorita_competente"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idEnteCompetente" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C083148ec-fb5b-4780-90d1-692a0b18cfbe" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_istanza"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idAutorizzazioneAmbientale" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cdafb4e8f-78ef-4b83-ad38-cc3522344a69" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_tipo_provvedimento"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idTipoProvvedimento" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cacd6e067-5d25-4b30-80b9-41734bc1b52a" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="tipo_provvedimento"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="tipoProvvedimento" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C99b6545e-77cb-467c-908a-f551daed0af2" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_stato"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idStato" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.retype" id="C93f43f0d-2fee-43d9-a397-4c10bfacd1be" priority="normal">
+        <source>
+            <class>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </class>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C37f79890-1675-4295-88c7-f211bf90a464" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="codice_sira"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="codiceSira" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C1c9631b6-8acf-44ed-bb67-1bca32c85713" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="descrizione"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="descrizione" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cdf7631d6-fea3-439c-b6bd-f0a3c5942a8d" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_attivita"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idAttivita" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="Cfa2e6b21-897c-4b98-8689-1fb60c18c30a" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_istanza"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idIstanza" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C0c76ad52-365d-4560-a868-e91ef46413cd" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_tematica"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="TematicaType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idTematica" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.join" id="Cf7968050-83c4-4a0f-ab54-c6fb0dd3bf35" priority="normal">
+        <source name="types">
+            <class>
+                <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <source name="types">
+            <class>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="StabilimentoType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </class>
+        </target>
+        <complexParameter name="join">
+            <jp:join-parameter xmlns:jp="http://www.esdi-humboldt.eu/hale/join">
+                <class>
+                    <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                </class>
+                <class>
+                    <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                </class>
+                <jp:condition>
+                    <property>
+                        <type name="decsira_geo_stabilimento" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                        <child name="codice_sira"/>
+                    </property>
+                    <property>
+                        <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                        <child name="codice_sira"/>
+                    </property>
+                </jp:condition>
+            </jp:join-parameter>
+        </complexParameter>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.join" id="C952e6cf1-e0ea-4678-8cda-0a3082fa32c6" priority="normal">
+        <source name="types">
+            <class>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <source name="types">
+            <class>
+                <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+            </class>
+        </source>
+        <target>
+            <class>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </class>
+        </target>
+        <complexParameter name="join">
+            <jp:join-parameter xmlns:jp="http://www.esdi-humboldt.eu/hale/join">
+                <class>
+                    <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                </class>
+                <class>
+                    <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                </class>
+                <jp:condition>
+                    <property>
+                        <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                        <child name="id_istanza"/>
+                    </property>
+                    <property>
+                        <type name="decsira_t_tematica" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                        <child name="id_istanza"/>
+                    </property>
+                </jp:condition>
+            </jp:join-parameter>
+        </complexParameter>
+    </cell>
+    <cell relation="eu.esdihumboldt.hale.align.rename" id="C47bf42a5-d2d5-4aef-aab4-a96c22f90e61" priority="normal">
+        <source>
+            <property>
+                <type name="decsira_t_autorizzazione_amb" ns="jdbc:postgresql:DBSIRASVIL:decsira"/>
+                <child name="id_autorizzamb_sede"/>
+            </property>
+        </source>
+        <target>
+            <property>
+                <type name="AutorizzazioneAmbientaleType" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+                <child name="idAutorizzazioneAmbientaleSede" ns="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"/>
+            </property>
+        </target>
+        <parameter value="false" name="ignoreNamespaces"/>
+        <parameter value="false" name="structuralRename"/>
+    </cell>
+</alignment>

--- a/security/app-schema/hale/autorizzazione_AEA.halex.styles.sld
+++ b/security/app-schema/hale/autorizzazione_AEA.halex.styles.sld
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:UserStyle xmlns="http://www.opengis.net/sld" xmlns:sld="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml">
+  <sld:Name>Default Styler</sld:Name>
+  <sld:FeatureTypeStyle>
+    <sld:Name>name</sld:Name>
+  </sld:FeatureTypeStyle>
+</sld:UserStyle>

--- a/security/app-schema/xsd/sira_AEA.xsd
+++ b/security/app-schema/xsd/sira_AEA.xsd
@@ -1,0 +1,313 @@
+<?xml version="1.0"?>
+<schema version="1.0" 
+    xmlns="http://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:siraemissioni="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"
+    targetNamespace="http://www.regione.piemonte.it/ambiente/siraemissioni/1.0"
+    elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <import namespace="http://www.opengis.net/gml/3.2" 
+	schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+	
+	
+	<!-- elements -->
+	<!-- qui estendono gml:AbstractObject o gml:AbstractFeature -->
+	
+	<!-- decsira_geo_stabilimento -->
+	<element name="Stabilimento" type="siraemissioni:StabilimentoType" substitutionGroup="gml:AbstractFeature" />
+	
+	<!-- decsira_t_autorizzazione_amb -->
+	<element name="AutorizzazioneAmbientale" type="siraemissioni:AutorizzazioneAmbientaleType" substitutionGroup="gml:AbstractObject" />
+	
+	<!-- decsira_t_tematica -->
+	<element name="Tematica" type="siraemissioni:TematicaType" substitutionGroup="gml:AbstractObject" />
+	
+
+	
+	<!-- types -->
+	<!-- qui estendono gml:AbstractGMLType o gml:AbstractFeatureType -->
+	
+	<complexType name="StabilimentoType">
+        <complexContent>
+            <extension base="gml:AbstractFeatureType">
+                <sequence>
+				    
+					<xs:element name="codiceSira" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="nome" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="istatComune" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="6" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="nomeComune" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="50" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					
+					<xs:element name="istatProvincia" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="6" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="desProvincia" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="50" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="indirizzo" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="200" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="emailPec" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="industriaAgroAlimentare" type="xs:integer" minOccurs="0" />
+					
+					<xs:element name="ricircoloInterno" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="modalitaRicircolo" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="percentualeRicircolo" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="volumeAnnuoRicircolo" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="volumeGiornoRicircolo" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="idStato" type="xs:integer" minOccurs="0" />
+					
+					<xs:element name="desStato" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="50" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="tipoProvvedimentoAttivo" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="tipoProvvedimentoStorico" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="tematica" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="idTipologiaImpianto" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="desTipologiaImpianto" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="abitantiEquivalentiTrattati" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="geometria" type="gml:GeometryPropertyType" minOccurs="1" />
+					
+					<!-- innesto oggetti piu complessi -->
+					
+					<!-- qui ci vuole un join -->
+					 <xs:element name="autorizzazioneAmbientale" type="siraemissioni:AutorizzazioneAmbientalePropertyType" minOccurs="0" maxOccurs="unbounded" />
+					
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+
+	
+	<complexType name="TematicaType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+				
+					<xs:element name="idTematica" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="50" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="idAttivita" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="idIstanza"  type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="codiceSira" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="descrizione" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="500" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+	
+	
+	
+	<complexType name="AutorizzazioneAmbientaleType">
+        <complexContent>
+            <extension base="gml:AbstractGMLType">
+                <sequence>
+				
+					<xs:element name="idAutorizzazioneAmbientaleSede" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="idAutorizzazioneAmbientale" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="idTipoProvvedimento" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="tipoProvvedimento" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="500" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="desTematica" minOccurs="1">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="1000" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="estremiProvvedimento" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="50" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="dataProvvedimento" type="xs:date" minOccurs="0" />
+					
+					<xs:element name="dataScadenza" type="xs:date" minOccurs="0" />
+					
+					<xs:element name="idEnteCompetente" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="desEnteCompetente" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="200" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<xs:element name="codiceSira" type="xs:decimal" minOccurs="1" />
+					
+					<xs:element name="idStato" type="xs:decimal" minOccurs="0" />
+					
+					<xs:element name="desStato" minOccurs="0">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:maxLength value="100" />
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:element>
+					
+					<!-- innesto gli oggetti piu complessi -->
+					
+					<!-- condizione di join mediante id_istanza -->
+					 <xs:element name="tematica" type="siraemissioni:TematicaPropertyType" minOccurs="1" maxOccurs="unbounded" />
+					
+                </sequence>
+            </extension>
+        </complexContent>
+    </complexType>
+	
+	<!-- property types -->
+	
+	
+	<complexType name="AutorizzazioneAmbientalePropertyType">
+        <sequence minOccurs="0">
+            <element ref="siraemissioni:AutorizzazioneAmbientale" />
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup" />
+        <attributeGroup ref="gml:OwnershipAttributeGroup" />
+    </complexType>
+	
+	
+	<complexType name="TematicaPropertyType">
+        <sequence minOccurs="0">
+            <element ref="siraemissioni:Tematica" />
+        </sequence>
+        <attributeGroup ref="gml:AssociationAttributeGroup" />
+        <attributeGroup ref="gml:OwnershipAttributeGroup" />
+    </complexType>
+	
+	</schema>


### PR DESCRIPTION
Sono stati rilasciati sia i file di configurazione json che il mapping Hale, attenzione che per non sovrascrivere lo schema xsd sipra_AEA.xsd ho inserito lo schema sira_AEA.xsd che è una configurazione intermedia per l'intero caso d'uso. Ho inserito anche lo script del db al cui interno c'è sia la struttura che i dati.