### PR TITLE
PDF file name is configurable in aua.json

### DIFF
--- a/frontend/assets/aua.json
+++ b/frontend/assets/aua.json
@@ -4,6 +4,7 @@
    "geometryName": "sira:geometria",
    "geometryType": "Point",
    "card": {
+     "pdfname": "AUA_{{/wfs:FeatureCollection/wfs:member/sira:AutorizzazioneUnicaAmbientale/sira:istanza/sira:IstanzaAutorizzativa/sira:nrProvvedimento/text()}}.pdf",
      "template": {
         "default": "assets/cardTemplate.jsxt",
         "QGIS": "assets/cardTemplate.QGIS.jsxt"


### PR DESCRIPTION
PDF file name is configurable, to pass model value just add {{xml_path}}
i.e
"card": {
     "pdfname": "AUA_{{/wfs:FeatureCollection/wfs:member/sira:AutorizzazioneUnicaAmbientale/sira:istanza/sira:IstanzaAutorizzativa/sira:nrProvvedimento/text()}}.pdf",
     "template": {
        "default": "assets/cardTemplate.jsxt",
        "QGIS": "assets/cardTemplate.QGIS.jsxt"
     }