### PR TITLE
Fixed Bugs on featureType config loading error and added profile base…

### DIFF
--- a/frontend/js/actions/__tests__/siradec-test.js
+++ b/frontend/js/actions/__tests__/siradec-test.js
@@ -27,7 +27,7 @@ describe('Test correctness of the queryform actions', () => {
             } catch(ex) {
                 done(ex);
             }
-        }, () => ({ueserprofile : {}}));
+        }, () => ({ueserprofile: {}}));
     });
 
     it('loads an existing configuration file 2', (done) => {

--- a/frontend/js/actions/__tests__/siradec-test.js
+++ b/frontend/js/actions/__tests__/siradec-test.js
@@ -27,7 +27,7 @@ describe('Test correctness of the queryform actions', () => {
             } catch(ex) {
                 done(ex);
             }
-        });
+        }, () => ({ueserprofile : {}}));
     });
 
     it('loads an existing configuration file 2', (done) => {

--- a/frontend/js/actions/siradec.js
+++ b/frontend/js/actions/siradec.js
@@ -169,7 +169,8 @@ function configurationLoading() {
 }
 function loadFeatureTypeConfig(configUrl, params, featureType, activate = false) {
     const url = configUrl ? configUrl : 'assets/' + featureType + '.json';
-    return (dispatch) => {
+    return (dispatch, getState) => {
+        const {userprofile} = getState();
         dispatch(configurationLoading());
         return axios.get(url).then((response) => {
             let config = response.data;
@@ -188,7 +189,7 @@ function loadFeatureTypeConfig(configUrl, params, featureType, activate = false)
             let serviceUrl = config.query.service.url;
 
             // Configure QueryForm attributes
-            const fields = config.query.fields.map((f) => {
+            const fields = config.query.fields.filter( (field) => !field.profile || field.profile.indexOf(userprofile.profile) !== -1).map((f) => {
                 let urlParams = config.query.service && config.query.service.urlParams ? assign({}, params, config.query.service.urlParams) : params;
                 urlParams = f.valueService && f.valueService.urlParams ? assign({}, urlParams, f.valueService.urlParams) : urlParams;
                 return f.valueService && f.valueService.urlParams ? getAttributeValuesPromise(f, urlParams, serviceUrl) : Promise.resolve(f);

--- a/frontend/js/components/SideQueryPanel.jsx
+++ b/frontend/js/components/SideQueryPanel.jsx
@@ -251,6 +251,7 @@ const SideQueryPanel = React.createClass({
     renderLoadConfigException(loadingError, msg) {
         let exception;
         if (isObject(loadingError)) {
+
             exception = loadingError.status +
                 "(" + loadingError.statusText + ")" +
                 ": " + loadingError.data;
@@ -310,7 +311,7 @@ const SideQueryPanel = React.createClass({
 });
 
 module.exports = connect((state) => {
-    const activeConfig = state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
+    const activeConfig = state.siradec.activeFeatureType && state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
     return {
         // SiraQueryPanel prop
         filterPanelExpanded: state.siradec.filterPanelExpanded,

--- a/frontend/js/containers/Sira.jsx
+++ b/frontend/js/containers/Sira.jsx
@@ -92,7 +92,7 @@ const {loadGetFeatureInfoConfig, setModelConfig} = require('../actions/mapInfo')
 const {selectFeatures, setFeatures} = require('../actions/featuregrid');
 
 const GetFeatureInfo = connect((state) => {
-    const activeConfig = state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
+    const activeConfig = state.siradec.activeFeatureType && state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
     return {
     siraFeatureTypeName: activeConfig.featureTypeName,
     siraFeatureInfoDetails: state.siradec.configOggetti,
@@ -203,7 +203,7 @@ const Sira = React.createClass({
 });
 
 module.exports = connect((state) => {
-    const activeConfig = state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
+    const activeConfig = state.siradec.activeFeatureType && state.siradec.configOggetti[state.siradec.activeFeatureType] || {};
     return {
         mode: 'desktop',
         loading: !state.config || !state.locale || false,

--- a/frontend/js/reducers/siradec.js
+++ b/frontend/js/reducers/siradec.js
@@ -134,15 +134,17 @@ function siradec(state = initialState, action) {
             });
         }
         case QUERYFORM_CONFIG_LOAD_ERROR: {
-            return {
+            return assign({}, state, {
+                configOggetti: {},
+                activeFeatureType: null,
                 loadingQueryFormConfigError: action.error,
-                fTypeConfigLoading: false
-            };
+                fTypeConfigLoading: false});
         }
         case QUERYFORM_HIDE_ERROR: {
-            return {
-                loadingQueryFormConfigError: null
-            };
+            return assign({}, state, {
+                    loadingQueryFormConfigError: null,
+                    filterPanelExpanded: false
+                });
         }
         default:
             return state;


### PR DESCRIPTION
…d fileds filter

To enable a field filtergin, just add "profile": ["A","C","F] in field configuration object in featureType configuration json file under frontend/assets ie: file aua.json
 "query": {
     "service": {
       "url":"{geoserverUrl}/ows?service=WFS&request=GetFeature",
       "urlParams": {
         "version": "1.1.0",
         "outputFormat": "application/json"
       }
     },
     "fields":[
        {
           "index": 1,
           "attribute": "sira:impianto/sira:Sede/sira:provincia",
           "label":"Provincia",
           "type":"list",
           "profile": ["A"]
           "valueService": {
             "urlParams": {
               "typeName": "sira:province"
             }
           },
           "valueId":"sigla",
           "valueLabel":"toponimo"
        },
...............
Provincia field will be visible only for user with profile A