### PR TITLE
#739: Filter row buffer issue fix

### DIFF
--- a/frontend/assets/application/conoscenze_ambientali/css/skin-dataset.css
+++ b/frontend/assets/application/conoscenze_ambientali/css/skin-dataset.css
@@ -38,6 +38,9 @@
 #decsiraweb-cartpanel .button-goToMap {
     background-color: #007e4f;
 }
+#decsiraweb-cartpanel .button-goToMap:hover {
+    color: #ffffff;
+}
 .dataset-tabs .nav-tabs{
     padding-left:30px;
     border-bottom:0;

--- a/frontend/assets/application/conoscenze_ambientali/css/skin-mappa.css
+++ b/frontend/assets/application/conoscenze_ambientali/css/skin-mappa.css
@@ -753,9 +753,8 @@ header.navbar h1 a span {
     background-color: #017f4f;
 }
 
-.mapbody .btn-default{
-    background-color:#017f4f;
-    color: #ffffff;
+.sira-ms2 .mapbody .btn-default{
+    color: #000000;
     border-color: #017f4f;
 }
 .mapbody .btn-default:hover{
@@ -853,6 +852,15 @@ header.navbar h1 a span {
 .side-querypanel .rw-state-focus {
     color: #017f4f !important;
     border: 1px solid #017f4f !important;
+}
+#fullscreen-container .ag-header-row{
+    background-color: #eaeaea;
+}
+#fullscreen-container .ag-body .ag-row-selected{
+    background-color: #b0e0e6 !important;
+}
+#fullscreen-container .ag-fresh .ag-cell-no-focus{
+    color: #000000;
 }
 #fullscreen-container, .side-querypanel .mapstore-switch-panel .panel-title{
     margin-bottom: 6px;

--- a/frontend/assets/css/fullscreen.css
+++ b/frontend/assets/css/fullscreen.css
@@ -200,10 +200,19 @@ div.mappaSiraDecisionale .querypanel-container .querypanel .panel-heading [class
     content: "\e252";
     font-family: inherit !important;
 }
+.querypanel-container .panel-title .m-slider{
+    background-color: #d1d1d1;
+}
+.querypanel-container .query-filter-container .no-border.btn-default{
+    background: #017f4f;
+}
 .querypanel-container .btn-default {
     color: #333;
     background-color: #fff;
     border-color: #ccc;
+}
+.querypanel-container .glyphicon-expand{
+    display: none;
 }
 .querypanel-container .glyphicon-expand:before {
     color: black;

--- a/frontend/assets/css/qgis.css
+++ b/frontend/assets/css/qgis.css
@@ -182,15 +182,27 @@
 div.mappaSiraDecisionale .querypanel-container .querypanel .panel-heading [class^="glyphicon-triangle-"]:before, [class*=" glyphicon-triangle-"]:before {
     font-family: inherit !important;
 }
+.querypanel-container .glyphicon-collapse-down{
+    display: none;
+}
 .querypanel-container .glyphicon-collapse-down:before {
     color: black;
     content: "\e252";
     font-family: inherit !important;
 }
+.querypanel-container .panel-title .m-slider{
+    background-color: #d1d1d1;
+}
+.querypanel-container .query-filter-container .no-border.btn-default{
+    background: #017f4f;
+}
 .querypanel-container .btn-default {
     color: #333;
     background-color: #fff;
     border-color: #ccc;
+}
+.querypanel-container .glyphicon-expand{
+    display: none;
 }
 .querypanel-container .glyphicon-expand:before {
     color: black;

--- a/frontend/assets/css/sira.css
+++ b/frontend/assets/css/sira.css
@@ -247,10 +247,19 @@
 div.mappaSiraDecisionale .querypanel-container .querypanel .panel-heading [class^="glyphicon-triangle-"]:before, [class*=" glyphicon-triangle-"]:before {
     font-family: inherit !important;
 }
+.querypanel-container .glyphicon-collapse-down{
+    display: none;
+}
 .querypanel-container .glyphicon-collapse-down:before {
     color: black;
     content: "\e252";
     font-family: inherit !important;
+}
+.querypanel-container .panel-title .m-slider{
+    background-color: #d1d1d1;
+}
+.querypanel-container .query-filter-container .no-border.btn-default{
+    background: #017f4f;
 }
 .querypanel-container .btn-default {
     color: #333;
@@ -446,7 +455,7 @@ flex: 3 1 80% !important;
     flex: 1 6 20%;
     height: 51px;
     box-shadow: 2px 2px 4px #A7A7A7;
-    background-color: #0a53a8 !important;
+    background-color: #017f4f !important;
     /*color: #5C9FB4 !important;*/
 
 }
@@ -502,7 +511,14 @@ flex: 3 1 80% !important;
     top: 20px;
     font-size: 10px;
 }
-
+#search-categories .tilescontainer, .dataset-mosaic-container a.list-group-item{
+    background-color: #009440;
+    border-color: transparent;
+}
+#search-categories .tilescontainer, .dataset-mosaic-container a.list-group-item:hover{
+    background-color: #ffffff;
+    border-color: transparent;
+}
 .toc-default-layer .toc-title {
     max-width: 230px;
     white-space: unset;

--- a/frontend/js/components/FeatureGrid.jsx
+++ b/frontend/js/components/FeatureGrid.jsx
@@ -414,7 +414,7 @@ class SiraGrid extends React.Component {
                                 paging={this.props.pagination}
                                 zoom={15}
                                 enableZoomToFeature={this.props.withMap}
-                                agGridOptions={{enableServerSideSorting: true, suppressMultiSort: true, overlayNoRowsTemplate: "Nessun risultato trovato"}}
+                                agGridOptions={{enableServerSideSorting: true,  rowBuffer: 20, suppressMultiSort: true, overlayNoRowsTemplate: "Nessun risultato trovato"}}
                                 zoomToFeatureAction={this.props.zoomToFeatureAction}
                                 toolbar={{
                                     zoom: this.props.withMap,

--- a/frontend/js/components/SiraFeatureGrid.jsx
+++ b/frontend/js/components/SiraFeatureGrid.jsx
@@ -331,7 +331,7 @@ class SiraFeatureGrid extends React.Component {
                                     maxZoom={16}
                                     paging={this.props.pagination}
                                     zoom={15}
-                                    agGridOptions={{enableServerSideSorting: true, suppressMultiSort: true}}
+                                    agGridOptions={{rowBuffer: 20, enableServerSideSorting: true, suppressMultiSort: true}}
                                     toolbar={{
                                         zoom: true,
                                         exporter: true,

--- a/frontend/js/containers/FullScreenPanel.jsx
+++ b/frontend/js/containers/FullScreenPanel.jsx
@@ -130,6 +130,7 @@ class FullScreen extends React.Component {
         return (
             <SideQueryPanel
                 withMap={false}
+                hideSpatialFilter
                 // authkey: (this.props.profile.authParams && this.props.profile.authParams.authkey) ? this.props.profile.authParams.authkey : '')
                 params={{authkey: this.props?.profile?.authParams?.authkey || ''}}
                 toggleControl={this.toggleControl}/>


### PR DESCRIPTION
## Description
As you perform filter, by default only first 3 rows are displayed which is not equal to the default row per page. The commit contains fix for row buffer to equal the default rows per page.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
Data grid displays only 3 rows of filtered results

**What is the new behavior?**
Data grid displays the rows equal to default rows per page of filtered results

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
