### PR TITLE
#738: SiranNoMap info load fix

### DIFF
--- a/frontend/SiraNoMap.html
+++ b/frontend/SiraNoMap.html
@@ -10,9 +10,6 @@
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
         <link rel="stylesheet" href="assets/application/conoscenze_ambientali/css/skin-mappa.css">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
-<!--        <link rel="stylesheet" href="assets/ms2-theme/default/css/css.css">-->
-<!--        <link rel="stylesheet" href="assets/ms2-theme/default/css/ms2-theme.css">-->
-<!--        <link rel="stylesheet" href="assets/ms2-theme/default/css/font.css">-->
         <script src="https://maps.google.com/maps/api/js?v=3"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.3.12/proj4.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.18.2/ol.js"></script>

--- a/frontend/js/siranomap/appConfig.js
+++ b/frontend/js/siranomap/appConfig.js
@@ -16,7 +16,8 @@ const appReducers = {
     featuregrid: require('../reducers/featuregrid'),
     draw: require('@mapstore/reducers/draw'),
     security: require('../reducers/siraSecurity'),
-    siraexporter: require('../reducers/siraexporter')
+    siraexporter: require('../reducers/siraexporter'),
+    siraTree: require('../reducers/siraTree')
 };
 
 module.exports = {


### PR DESCRIPTION
## Description
Crash fix for SiraNoMap on loading info of the selected row 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
Upon clicking the info icon on a filtered row, the application crashes

**What is the new behavior?**
Upon clicking the info icon on a filtered row, the information modal is displayed of the selected row

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
