### PR TITLE
#806 - Query builder icons overlap fix

### DIFF
--- a/frontend/assets/css/sira.css
+++ b/frontend/assets/css/sira.css
@@ -123,10 +123,6 @@
     overflow-y: auto;
     width: 100% !important;
 }
-.side-querypanel #add-condition-group{
-   position: relative;
-   left: 60px;
-}
 .side-querypanel #attributeFilterPanel .logicHeader .col-xs-5 {
     width: 50% !important;
 }


### PR DESCRIPTION
## Description
This PR adds fix to the icons overlapping in query builder 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
 - [x] Bugfix

##Issue

**What is the current behavior?**
#806  

**What is the new behavior?**
The group and delete icon will not be superimposed.

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
