### PR TITLE
#873: MappaScheda when no geometry

### DIFF
--- a/frontend/js/components/template/PreviewMap.jsx
+++ b/frontend/js/components/template/PreviewMap.jsx
@@ -55,57 +55,8 @@ class PreviewMap extends React.Component {
         }
     }
 
-    fillUrl = (layer) => {
-        if (layer.url) {
-            return assign({}, layer, {
-                url: layer.url.replace("{geoserverUrl}", ConfigUtils.getConfigProp('geoserverUrl'))
-            });
-        }
-        return layer;
-    };
-
-    render() {
-        const extent = this.getExtent();
-        const zoom = this.getZoom(extent);
-        const center = this.getCenter(extent);
-        return this.props.map && this.props.center && this.props.center.coordinates ?
-            (
-                <div>
-                    <PMap
-                        ref="mappa"
-                        {...this.props.map}
-                        style={this.props.style}
-                        mapOptions={{interactions: {
-                            doubleClickZoom: false,
-                            dragPan: false,
-                            altShiftDragRotate: false,
-                            keyboard: false,
-                            mouseWheelZoom: false,
-                            shiftDragZoom: false,
-                            pinchRotate: false,
-                            pinchZoom: false
-                        }, view: {resolutions: this.props.map.resolutions}}}
-                        registerHooks={false}
-                        zoomControl={false}
-                        zoom={zoom}
-                        center={center}
-                        id="scheda_pMap">
-                        {
-                            this.props.layers.map((layer, index) =>
-                                <Layer key={layer.title || layer.name} position={index} type={layer.type}
-                                    options={assign({}, this.fillUrl(layer), {params: {authkey: this.props.authParam && this.props.authParam.authkey ? this.props.authParam.authkey : ''}})}/>
-                            )
-                        }
-                    </PMap>
-                    <Button onClick={this.changeMapView} style={{position: "relative", top: "-" + this.props.style.height, 'float': "right", margin: "2px"}}>
-                        <img src={img} width={16}/>
-                    </Button>
-                </div>
-            ) : <span/>;
-    }
-
     getExtent = () => {
-        const geometries = [this.props.center];
+        const geometries = [this.props.center] || [];
         return geometries.reduce((prev, next) => {
             return CoordinatesUtils.extendExtent(prev, CoordinatesUtils.getGeoJSONExtent(next));
         }, CoordinatesUtils.getGeoJSONExtent(geometries[0]));
@@ -126,6 +77,53 @@ class PreviewMap extends React.Component {
         }, 0, 16);
     }
 
+    render() {
+
+        const extent = this.props.center && this.getExtent();
+        return this.props.map ?
+            (
+                <div>
+                    <PMap
+                        ref="mappa"
+                        {...this.props.map}
+                        style={this.props.style}
+                        mapOptions={{interactions: {
+                            doubleClickZoom: false,
+                            dragPan: false,
+                            altShiftDragRotate: false,
+                            keyboard: false,
+                            mouseWheelZoom: false,
+                            shiftDragZoom: false,
+                            pinchRotate: false,
+                            pinchZoom: false
+                        }, view: {resolutions: this.props.map.resolutions}}}
+                        registerHooks={false}
+                        zoomControl={false}
+                        {...(extent && {zoom: this.getZoom(extent), center: this.getCenter(extent)})}
+                        id="scheda_pMap">
+                        {
+                            this.props.layers.map((layer, index) =>
+                                <Layer key={layer.title || layer.name} position={index} type={layer.type}
+                                    options={assign({}, this.fillUrl(layer), {params: {authkey: this.props.authParam && this.props.authParam.authkey ? this.props.authParam.authkey : ''}})}/>
+                            )
+                        }
+                    </PMap>
+                    {extent && <Button onClick={this.changeMapView} style={{position: "relative", top: "-" + this.props.style.height, 'float': "right", margin: "2px"}}>
+                        <img alt="zoom-to" src={img} width={16}/>
+                    </Button>}
+                </div>
+            ) : <span/>;
+    }
+
+    fillUrl = (layer) => {
+        if (layer.url) {
+            return assign({}, layer, {
+                url: layer.url.replace("{geoserverUrl}", ConfigUtils.getConfigProp('geoserverUrl'))
+            });
+        }
+        return layer;
+    };
+
     changeMapView = () => {
         const extent = this.getExtent();
         const center = this.getCenter(extent);
@@ -140,7 +138,7 @@ class PreviewMap extends React.Component {
 
 module.exports = connect((state) => {
     return {
-        map: (state.map && state.map && state.map.present) || (state.config && state.config.map),
+        map: (state.map && state.map.present) || (state.config && state.config.map),
         activeSections: state.cardtemplate.activeSections || {}
     };
 }, {


### PR DESCRIPTION
## Description
This PR adds commits to show map with only background when feature has no geometry in the MappaScheda (Preview Map)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: https://github.com/geosolutions-it/MapStore2/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x", remove the others)
- [x] Enhancement

##Issue

**What is the current behavior?**
#873 

**What is the new behavior?**
- When feature has no geometry, the opening card will not crash and MappaScheda will be displayed with background and no zoom

## Breaking change
**Does this PR introduce a breaking change?** (check one with "x", remove the other)
 - [ ] Yes, and I documented them in migration notes
 - [x] No

## Other useful information
